### PR TITLE
Add stage-first SGE execution skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .[dev]
-      - name: Smoke test CLI
+      - name: Run checks
         run: |
+          python -m pytest
+          python -m mypy src
+          python -m ruff check .
           bidsflow --help
           bidsflow status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, master]
   pull_request:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,8 +23,15 @@ jobs:
           python -m pip install -e .[dev]
       - name: Run checks
         run: |
-          python -m pytest
+          python -m pytest --cov=src/bidsflow --cov-report=xml --cov-report=term-missing
           python -m mypy src
           python -m ruff check .
           bidsflow --help
           bidsflow status
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          use_oidc: true
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.coverage
+coverage.xml
+htmlcov/
 dist/
 build/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ At the current stage, BIDSFlow is **not** intended to:
 ```bash
 bidsflow init
 bidsflow doctor
-bidsflow validate
+bidsflow config validate
 bidsflow curate
+bidsflow validate
 bidsflow fmriprep
 bidsflow mriqc
 bidsflow xcpd
@@ -121,8 +122,8 @@ BIDSFlow/
 
 This scaffold establishes the **project boundary**, **stage model**,
 **handoff contract**, and a **minimal CLI skeleton**. The current SGE
-work also includes config loading and a qsub planning preview for stage
-execution units. The next
+work also includes config loading plus stage-level `--dry-run` preview
+and submission through the configured scheduler. The next
 implementation milestones should focus on:
 
 1. configuration parsing and normalization
@@ -151,9 +152,10 @@ bidsflow --help
 ```bash
 bidsflow init --path .
 bidsflow doctor
-bidsflow validate --config examples/project.toml
-bidsflow scheduler plan-sge fmriprep \
+bidsflow config validate --config examples/project.toml
+bidsflow fmriprep \
   --config examples/project.toml \
-  --participant sub-001
+  --participant sub-001 \
+  --dry-run
 bidsflow curate --config examples/project.toml --participant sub-001
 ```

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ implementation milestones should focus on:
 
 - [Stage model](docs/design/stage-model.md)
 - [Handoff contract](docs/design/handoff-contract.md)
+- [SGE site configuration](docs/setup/sge-site-config.md)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # BIDSFlow
 
+[![CI](https://github.com/psychelzh/BIDSFlow/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/psychelzh/BIDSFlow/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/psychelzh/BIDSFlow/graph/badge.svg?branch=main)](https://app.codecov.io/github/psychelzh/BIDSFlow)
+
 ## A Python CLI Orchestrator for BIDS Apps
 
 BIDSFlow is an extensible Python CLI toolkit for orchestrating staged

--- a/README.md
+++ b/README.md
@@ -90,15 +90,28 @@ BIDSFlow/
 │     ├─ __init__.py
 │     ├─ cli.py
 │     ├─ config/
+│     │  ├─ load.py
 │     │  └─ models.py
-│     └─ core/
+│     ├─ core/
 │        └─ stages.py
+│     └─ scheduler/
+│        ├─ __init__.py
+│        ├─ models.py
+│        └─ sge.py
 ├─ docs/
 │  └─ design/
 │     ├─ stage-model.md
 │     └─ handoff-contract.md
 ├─ examples/
 │  └─ project.toml
+├─ tests/
+│  ├─ test_config_load.py
+│  └─ test_scheduler_sge.py
+├─ .codex/
+│  └─ skills/
+│     ├─ project-config-schema/
+│     ├─ bids-app-command-builder/
+│     └─ cluster-runner-sge/
 └─ .github/
    └─ workflows/
       └─ ci.yml
@@ -107,7 +120,9 @@ BIDSFlow/
 ## Current development status
 
 This scaffold establishes the **project boundary**, **stage model**,
-**handoff contract**, and a **minimal CLI skeleton**. The next
+**handoff contract**, and a **minimal CLI skeleton**. The current SGE
+work also includes config loading and a qsub planning preview for stage
+execution units. The next
 implementation milestones should focus on:
 
 1. configuration parsing and normalization
@@ -126,6 +141,7 @@ implementation milestones should focus on:
 
 ```bash
 python -m pip install -e .[dev]
+python --version  # Python 3.11+
 bidsflow --help
 ```
 
@@ -135,5 +151,8 @@ bidsflow --help
 bidsflow init --path .
 bidsflow doctor
 bidsflow validate --config examples/project.toml
+bidsflow scheduler plan-sge fmriprep \
+  --config examples/project.toml \
+  --participant sub-001
 bidsflow curate --config examples/project.toml --participant sub-001
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"

--- a/docs/setup/sge-site-config.md
+++ b/docs/setup/sge-site-config.md
@@ -6,8 +6,9 @@ Use this guide to adapt BIDSFlow's SGE settings to a specific cluster
 site, especially for Debian-packaged Son of Grid Engine deployments.
 
 The example config in `examples/project.toml` is intentionally
-conservative. It is meant to help you submit a lightweight smoke-test
-job first, then layer on site-specific queue, PE, and resource settings.
+conservative. It is meant to help you preview and submit a lightweight
+placeholder stage first, then layer on site-specific queue, PE, and
+resource settings.
 
 ## Inspect The Site
 
@@ -86,24 +87,24 @@ For a conservative first pass, prefer `mem_free` over `h_vmem`.
 1. Validate the config:
 
 ```bash
-bidsflow validate --config examples/project.toml
+bidsflow config validate --config examples/project.toml
 ```
 
-1. Preview the SGE submission plan:
+1. Preview the stage invocation:
 
 ```bash
-bidsflow scheduler plan-sge fmriprep \
+bidsflow fmriprep \
   --config examples/project.toml \
-  --participant sub-001
+  --participant sub-001 \
+  --dry-run
 ```
 
 1. Submit the lightweight placeholder job:
 
 ```bash
-bidsflow scheduler plan-sge fmriprep \
+bidsflow fmriprep \
   --config examples/project.toml \
-  --participant sub-001 \
-  --submit
+  --participant sub-001
 ```
 
 At the current development stage, this submits a lightweight BIDSFlow

--- a/docs/setup/sge-site-config.md
+++ b/docs/setup/sge-site-config.md
@@ -1,0 +1,122 @@
+# SGE Site Configuration
+
+## Goal
+
+Use this guide to adapt BIDSFlow's SGE settings to a specific cluster
+site, especially for Debian-packaged Son of Grid Engine deployments.
+
+The example config in `examples/project.toml` is intentionally
+conservative. It is meant to help you submit a lightweight smoke-test
+job first, then layer on site-specific queue, PE, and resource settings.
+
+## Inspect The Site
+
+Before changing the config, inspect the cluster's available settings:
+
+```bash
+qconf -sql
+qconf -spl
+qconf -sc
+```
+
+Use them as follows:
+
+- `qconf -sql`: choose a valid queue name
+- `qconf -spl`: choose a valid parallel environment, if needed
+- `qconf -sc`: choose valid resource names for walltime and memory
+
+Useful focused queries:
+
+```bash
+qconf -sc | grep -E 'h_rt|h_vmem|mem_free|tmp_free'
+```
+
+## Conservative First Submission
+
+Start with a single-slot job and no parallel environment:
+
+```toml
+[scheduler.sge]
+driver = "cli"
+queue = "short.q"
+inherit_cwd = true
+export_env = false
+poll_interval_sec = 15
+
+[scheduler.sge.default_resources]
+slots = 1
+walltime = "00:10:00"
+memory = "1G"
+
+[scheduler.sge.resource_map]
+walltime = "h_rt"
+memory = "mem_free"
+```
+
+This minimizes the number of site-specific assumptions.
+
+## When To Set These Fields
+
+Set `queue` when your site expects jobs to target a specific queue.
+
+Set `project` only if your site requires `qsub -P ...`. If you are not
+sure, leave it unset at first.
+
+Set `parallel_environment` only when:
+
+- the queue supports multi-slot jobs
+- you have confirmed the PE name from `qconf -spl`
+
+If your site only reports `ompi`, do not use `smp`.
+
+## Memory And Time Mapping
+
+Do not assume all SGE sites use the same resource names.
+
+Common patterns include:
+
+- `h_rt` for hard runtime limit
+- `h_vmem` for hard memory limit
+- `mem_free` for scheduler-side free-memory requests
+
+For a conservative first pass, prefer `mem_free` over `h_vmem`.
+
+## Validation Workflow
+
+1. Validate the config:
+
+```bash
+bidsflow validate --config examples/project.toml
+```
+
+1. Preview the SGE submission plan:
+
+```bash
+bidsflow scheduler plan-sge fmriprep \
+  --config examples/project.toml \
+  --participant sub-001
+```
+
+1. Submit the lightweight placeholder job:
+
+```bash
+bidsflow scheduler plan-sge fmriprep \
+  --config examples/project.toml \
+  --participant sub-001 \
+  --submit
+```
+
+At the current development stage, this submits a lightweight BIDSFlow
+placeholder command rather than a real fMRIPrep container invocation.
+
+## Troubleshooting
+
+If submission fails, compare the generated `qsub` options against the
+site output from `qconf`.
+
+Most early failures come from:
+
+- an invalid queue name
+- an invalid project name
+- a missing or incorrect parallel environment
+- resource names that do not exist on the site

--- a/docs/setup/sge-site-config.md
+++ b/docs/setup/sge-site-config.md
@@ -38,7 +38,6 @@ Start with a single-slot job and no parallel environment:
 
 ```toml
 [scheduler.sge]
-driver = "cli"
 queue = "short.q"
 inherit_cwd = true
 export_env = false

--- a/examples/project.toml
+++ b/examples/project.toml
@@ -18,7 +18,6 @@ max_jobs = 4
 #   qconf -sql
 #   qconf -spl
 #   qconf -sc
-driver = "cli"
 queue = "short.q"
 inherit_cwd = true
 export_env = false

--- a/examples/project.toml
+++ b/examples/project.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Example BIDSFlow project"
-root = "."
+root = ".."
 bids_root = "sourcedata/raw"
 derivatives_root = "derivatives"
 

--- a/examples/project.toml
+++ b/examples/project.toml
@@ -13,26 +13,25 @@ state_root = "state"
 max_jobs = 4
 
 [scheduler.sge]
-# Adjust these values to match your site-specific SoGE setup.
+# Start from the most conservative settings and confirm site-specific
+# values with:
+#   qconf -sql
+#   qconf -spl
+#   qconf -sc
 driver = "cli"
-queue = "all.q"
-project = "neuro"
-parallel_environment = "smp"
+queue = "short.q"
 inherit_cwd = true
 export_env = false
 poll_interval_sec = 15
 
 [scheduler.sge.default_resources]
-slots = 8
-walltime = "24:00:00"
-memory = "32G"
+slots = 1
+walltime = "00:10:00"
+memory = "1G"
 
 [scheduler.sge.resource_map]
 walltime = "h_rt"
-memory = "h_vmem"
-
-[scheduler.sge.extra_requests]
-tmp_free = "20G"
+memory = "mem_free"
 
 [heudiconv]
 enabled = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",
+  "pytest-cov>=5.0",
   "ruff>=0.5",
   "mypy>=1.10",
 ]
@@ -41,3 +42,11 @@ target-version = "py311"
 
 [tool.pytest.ini_options]
 addopts = "-q"
+
+[tool.coverage.run]
+branch = true
+source = ["src/bidsflow"]
+
+[tool.coverage.report]
+skip_empty = true
+show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "bidsflow"
 version = "0.1.0a0"
 description = "A Python CLI orchestrator for BIDS Apps"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
   { name = "Liang Zhang" }
 ]
@@ -37,7 +37,7 @@ packages = ["src/bidsflow"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py310"
+target-version = "py311"
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/src/bidsflow/cli.py
+++ b/src/bidsflow/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import shlex
 import shutil
 from pathlib import Path
+from typing import Literal
 
 import typer
 from rich.console import Console
@@ -12,14 +13,17 @@ from rich.table import Table
 from bidsflow.config.load import load_config
 from bidsflow.config.models import Config
 from bidsflow.core.stages import STAGES, StageId
+from bidsflow.scheduler.models import SubmittedJob
 from bidsflow.scheduler.sge import SGECliScheduler
+
+SchedulerChoice = Literal["local", "sge"]
 
 app = typer.Typer(
     help="BIDSFlow: a staged Python CLI orchestrator for BIDS Apps.",
     no_args_is_help=True,
 )
-scheduler_app = typer.Typer(help="Scheduler planning and submission helpers.")
-app.add_typer(scheduler_app, name="scheduler")
+config_app = typer.Typer(help="Configuration helpers.")
+app.add_typer(config_app, name="config")
 console = Console()
 
 
@@ -61,9 +65,9 @@ def doctor(
     console.print(table)
 
 
-@app.command()
-def validate(config: Path = typer.Option(..., exists=True, help="Path to TOML config.")) -> None:
-    """Validate project configuration and stage inputs."""
+@config_app.command("validate")
+def config_validate(config: Path = typer.Option(..., exists=True, help="Path to TOML config.")) -> None:
+    """Validate project configuration and execution settings."""
     loaded = load_config(config)
     table = Table(title="Validated BIDSFlow config")
     table.add_column("Field")
@@ -80,60 +84,6 @@ def validate(config: Path = typer.Option(..., exists=True, help="Path to TOML co
 
 
 @app.command()
-def curate(
-    config: Path = typer.Option(..., exists=True, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
-) -> None:
-    """Run HeuDiConv-backed curation."""
-    console.print(f"Curate stage requested with config={config} participant={participant}")
-
-
-@app.command()
-def fmriprep(
-    config: Path = typer.Option(..., exists=True, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
-) -> None:
-    """Run fMRIPrep stage."""
-    console.print(f"fMRIPrep stage requested with config={config} participant={participant}")
-
-
-@app.command()
-def mriqc(
-    config: Path = typer.Option(..., exists=True, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
-) -> None:
-    """Run MRIQC stage."""
-    console.print(f"MRIQC stage requested with config={config} participant={participant}")
-
-
-@app.command(name="xcpd")
-def xcpd_cmd(
-    config: Path = typer.Option(..., exists=True, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
-) -> None:
-    """Run XCP-D stage."""
-    console.print(f"XCP-D stage requested with config={config} participant={participant}")
-
-
-@app.command()
-def qsiprep(
-    config: Path = typer.Option(..., exists=True, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
-) -> None:
-    """Run QSIPrep stage."""
-    console.print(f"QSIPrep stage requested with config={config} participant={participant}")
-
-
-@app.command()
-def qsirecon(
-    config: Path = typer.Option(..., exists=True, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
-) -> None:
-    """Run QSIRecon stage."""
-    console.print(f"QSIRecon stage requested with config={config} participant={participant}")
-
-
-@app.command()
 def status() -> None:
     """Display the current stage registry."""
     table = Table(title="BIDSFlow stages")
@@ -147,135 +97,323 @@ def status() -> None:
     console.print(table)
 
 
-def _load_sge_scheduler(config: Path) -> tuple[Config, SGECliScheduler]:
-    loaded = load_config(config)
-    if loaded.execution.scheduler != "sge":
-        raise typer.BadParameter(
-            f"Config scheduler is '{loaded.execution.scheduler}', expected 'sge' for this command."
-        )
-    return loaded, SGECliScheduler(loaded.scheduler.sge)
+def _resolve_scheduler(config: Config, scheduler: SchedulerChoice | None) -> SchedulerChoice:
+    return config.execution.scheduler if scheduler is None else scheduler
 
 
-@scheduler_app.command("plan-sge")
-def scheduler_plan_sge(
-    stage: StageId = typer.Argument(..., help="Stage id to schedule."),
-    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
-    hold_jid: str | None = typer.Option(None, help="Optional upstream SGE job id dependency."),
-    submit: bool = typer.Option(
-        False,
-        help="Submit with qsub after rendering the plan instead of only printing it.",
-    ),
+def _ensure_stage_scope(stage: StageId, participant: str | None) -> None:
+    stage_spec = STAGES[stage]
+    if stage_spec.scope == "dataset" and participant is not None:
+        console.print(f"Stage '{stage.value}' has dataset scope and does not accept --participant.")
+        raise typer.Exit(code=2)
+
+
+def _build_local_stage_command(
+    *,
+    stage: StageId,
+    config_path: Path,
+    participant: str | None,
+) -> tuple[str, ...]:
+    command = (
+        "bidsflow",
+        stage.value,
+        "--config",
+        str(config_path.resolve()),
+        "--scheduler",
+        "local",
+    )
+    if participant is None:
+        return command
+    return (*command, "--participant", participant)
+
+
+def _print_local_stage_preview(
+    *,
+    stage: StageId,
+    config_path: Path,
+    participant: str | None,
+    loaded: Config,
 ) -> None:
-    """Preview or submit an SGE qsub plan for a stage execution unit."""
-    loaded, scheduler = _load_sge_scheduler(config)
-    plan = scheduler.plan_stage_submission(
+    command = _build_local_stage_command(
+        stage=stage,
+        config_path=config_path,
+        participant=participant,
+    )
+    table = Table(title="Local stage run preview")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("stage", stage.value)
+    table.add_row("participant", participant or "-")
+    table.add_row("scheduler", "local")
+    table.add_row("cwd", str(loaded.project.root))
+    table.add_row("command", shlex.join(command))
+    console.print(table)
+
+
+def _run_local_stage(stage: StageId, config_path: Path, participant: str | None) -> None:
+    stage_spec = STAGES[stage]
+    console.print(
+        f"{stage_spec.label} stage requested with config={config_path.resolve()} "
+        f"participant={participant or '-'}"
+    )
+
+
+def _load_sge_scheduler(config: Config) -> SGECliScheduler:
+    return SGECliScheduler(config.scheduler.sge)
+
+
+def _print_sge_stage_preview(
+    *,
+    stage: StageId,
+    participant: str | None,
+    plan_script: str,
+    plan_command: tuple[str, ...],
+    launch_command: tuple[str, ...],
+    script_path: Path,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> None:
+    table = Table(title="SGE stage run preview")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("stage", stage.value)
+    table.add_row("participant", participant or "-")
+    table.add_row("scheduler", "sge")
+    table.add_row("script path", str(script_path))
+    table.add_row("stdout", str(stdout_path))
+    table.add_row("stderr", str(stderr_path))
+    table.add_row("command", shlex.join(launch_command))
+    table.add_row("qsub", shlex.join(plan_command))
+    console.print(table)
+    console.print(Syntax(plan_script, "sh", theme="ansi_dark", line_numbers=True))
+
+
+def _run_stage(
+    *,
+    stage: StageId,
+    config: Path,
+    participant: str | None,
+    scheduler: SchedulerChoice | None,
+    dry_run: bool,
+    hold_jid: str | None,
+) -> None:
+    loaded = load_config(config)
+    _ensure_stage_scope(stage, participant)
+    effective_scheduler = _resolve_scheduler(loaded, scheduler)
+
+    if effective_scheduler == "local":
+        if hold_jid is not None:
+            console.print("--hold-jid is only supported when --scheduler sge is active.")
+            raise typer.Exit(code=2)
+        if dry_run:
+            _print_local_stage_preview(
+                stage=stage,
+                config_path=config,
+                participant=participant,
+                loaded=loaded,
+            )
+            return
+        _run_local_stage(stage=stage, config_path=config, participant=participant)
+        return
+
+    scheduler_runner = _load_sge_scheduler(loaded)
+    plan = scheduler_runner.plan_stage_submission(
         config_path=config,
         config=loaded,
         stage=stage,
         participant=participant,
         hold_jid=hold_jid,
     )
-
-    table = Table(title="SGE submission plan")
-    table.add_column("Field")
-    table.add_column("Value")
-    table.add_row("stage", stage.value)
-    table.add_row("participant", participant or "-")
-    table.add_row("job name", plan.launch.job_name)
-    table.add_row("script path", str(plan.script_path))
-    table.add_row("stdout", str(plan.launch.stdout_path))
-    table.add_row("stderr", str(plan.launch.stderr_path))
-    table.add_row("qsub", shlex.join(plan.qsub_command))
-    console.print(table)
-    console.print(Syntax(plan.script_text, "bash", theme="ansi_dark", line_numbers=True))
-
-    if submit:
-        submitted = scheduler.submit(plan)
-        console.print(f"Submitted SGE job {submitted.job_id}")
-
-
-@scheduler_app.command("status-sge")
-def scheduler_status_sge(
-    job_id: str = typer.Option(..., help="SGE job id to inspect."),
-    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    accounting: bool = typer.Option(
-        False,
-        help="Fall back to qacct if the job is no longer present in qstat.",
-    ),
-) -> None:
-    """Inspect the live or completed status of an SGE job."""
-    _, scheduler = _load_sge_scheduler(config)
-    job_status = scheduler.status(job_id)
-
-    if job_status is not None:
-        table = Table(title="SGE job status")
-        table.add_column("Field")
-        table.add_column("Value")
-        table.add_row("job id", job_status.job_id)
-        table.add_row("name", job_status.name)
-        table.add_row("state", job_status.state)
-        table.add_row("owner", job_status.owner or "-")
-        table.add_row("queue", job_status.queue_name or "-")
-        table.add_row("slots", str(job_status.slots) if job_status.slots is not None else "-")
-        console.print(table)
+    _print_sge_stage_preview(
+        stage=stage,
+        participant=participant,
+        plan_script=plan.script_text,
+        plan_command=plan.qsub_command,
+        launch_command=plan.launch.command,
+        script_path=plan.script_path,
+        stdout_path=plan.launch.stdout_path,
+        stderr_path=plan.launch.stderr_path,
+    )
+    if dry_run:
         return
 
-    if accounting:
-        job_accounting = scheduler.accounting(job_id)
-        if job_accounting is not None:
-            table = Table(title="SGE job accounting")
-            table.add_column("Field")
-            table.add_column("Value")
-            table.add_row("job id", job_accounting.job_id)
-            table.add_row("exit status", job_accounting.exit_status or "-")
-            table.add_row("failed", job_accounting.failed or "-")
-            table.add_row("wallclock", job_accounting.wallclock or "-")
-            table.add_row("cpu", job_accounting.cpu or "-")
-            table.add_row("maxvmem", job_accounting.maxvmem or "-")
-            console.print(table)
-            return
-
-    console.print(f"No SGE status information found for job {job_id}.")
-    raise typer.Exit(code=1)
+    submitted: SubmittedJob = scheduler_runner.submit(plan)
+    console.print(f"Submitted SGE job {submitted.job_id}")
 
 
-@scheduler_app.command("accounting-sge")
-def scheduler_accounting_sge(
-    job_id: str = typer.Option(..., help="SGE job id to inspect via qacct."),
+@app.command()
+def curate(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    scheduler: SchedulerChoice | None = typer.Option(
+        None,
+        help="Override the scheduler declared in the config for this invocation.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the stage execution without running it."),
+    hold_jid: str | None = typer.Option(
+        None,
+        help="Optional upstream SGE job id dependency when using --scheduler sge.",
+    ),
 ) -> None:
-    """Inspect qacct information for a completed SGE job."""
-    _, scheduler = _load_sge_scheduler(config)
-    job_accounting = scheduler.accounting(job_id)
-    if job_accounting is None:
-        console.print(
-            f"No qacct information found for job {job_id}. "
-            "Your SGE site may not have accounting enabled yet."
-        )
-        raise typer.Exit(code=1)
-
-    table = Table(title="SGE job accounting")
-    table.add_column("Field")
-    table.add_column("Value")
-    table.add_row("job id", job_accounting.job_id)
-    table.add_row("exit status", job_accounting.exit_status or "-")
-    table.add_row("failed", job_accounting.failed or "-")
-    table.add_row("wallclock", job_accounting.wallclock or "-")
-    table.add_row("cpu", job_accounting.cpu or "-")
-    table.add_row("maxvmem", job_accounting.maxvmem or "-")
-    console.print(table)
+    """Run or preview the HeuDiConv-backed curation stage."""
+    _run_stage(
+        stage=StageId.CURATE,
+        config=config,
+        participant=participant,
+        scheduler=scheduler,
+        dry_run=dry_run,
+        hold_jid=hold_jid,
+    )
 
 
-@scheduler_app.command("cancel-sge")
-def scheduler_cancel_sge(
-    job_id: str = typer.Option(..., help="SGE job id to cancel."),
+@app.command(name="validate")
+def validate_stage(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    scheduler: SchedulerChoice | None = typer.Option(
+        None,
+        help="Override the scheduler declared in the config for this invocation.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the stage execution without running it."),
+    hold_jid: str | None = typer.Option(
+        None,
+        help="Optional upstream SGE job id dependency when using --scheduler sge.",
+    ),
 ) -> None:
-    """Cancel an SGE job with qdel."""
-    _, scheduler = _load_sge_scheduler(config)
-    command = scheduler.cancel(job_id)
-    console.print(f"Ran {shlex.join(command)}")
+    """Run or preview the validation stage."""
+    _run_stage(
+        stage=StageId.VALIDATE,
+        config=config,
+        participant=participant,
+        scheduler=scheduler,
+        dry_run=dry_run,
+        hold_jid=hold_jid,
+    )
+
+
+@app.command()
+def fmriprep(
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    scheduler: SchedulerChoice | None = typer.Option(
+        None,
+        help="Override the scheduler declared in the config for this invocation.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the stage execution without running it."),
+    hold_jid: str | None = typer.Option(
+        None,
+        help="Optional upstream SGE job id dependency when using --scheduler sge.",
+    ),
+) -> None:
+    """Run or preview the fMRIPrep stage."""
+    _run_stage(
+        stage=StageId.FMRIPREP,
+        config=config,
+        participant=participant,
+        scheduler=scheduler,
+        dry_run=dry_run,
+        hold_jid=hold_jid,
+    )
+
+
+@app.command()
+def mriqc(
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    scheduler: SchedulerChoice | None = typer.Option(
+        None,
+        help="Override the scheduler declared in the config for this invocation.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the stage execution without running it."),
+    hold_jid: str | None = typer.Option(
+        None,
+        help="Optional upstream SGE job id dependency when using --scheduler sge.",
+    ),
+) -> None:
+    """Run or preview the MRIQC stage."""
+    _run_stage(
+        stage=StageId.MRIQC,
+        config=config,
+        participant=participant,
+        scheduler=scheduler,
+        dry_run=dry_run,
+        hold_jid=hold_jid,
+    )
+
+
+@app.command(name="xcpd")
+def xcpd_cmd(
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    scheduler: SchedulerChoice | None = typer.Option(
+        None,
+        help="Override the scheduler declared in the config for this invocation.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the stage execution without running it."),
+    hold_jid: str | None = typer.Option(
+        None,
+        help="Optional upstream SGE job id dependency when using --scheduler sge.",
+    ),
+) -> None:
+    """Run or preview the XCP-D stage."""
+    _run_stage(
+        stage=StageId.XCPD,
+        config=config,
+        participant=participant,
+        scheduler=scheduler,
+        dry_run=dry_run,
+        hold_jid=hold_jid,
+    )
+
+
+@app.command()
+def qsiprep(
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    scheduler: SchedulerChoice | None = typer.Option(
+        None,
+        help="Override the scheduler declared in the config for this invocation.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the stage execution without running it."),
+    hold_jid: str | None = typer.Option(
+        None,
+        help="Optional upstream SGE job id dependency when using --scheduler sge.",
+    ),
+) -> None:
+    """Run or preview the QSIPrep stage."""
+    _run_stage(
+        stage=StageId.QSIPREP,
+        config=config,
+        participant=participant,
+        scheduler=scheduler,
+        dry_run=dry_run,
+        hold_jid=hold_jid,
+    )
+
+
+@app.command()
+def qsirecon(
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    scheduler: SchedulerChoice | None = typer.Option(
+        None,
+        help="Override the scheduler declared in the config for this invocation.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the stage execution without running it."),
+    hold_jid: str | None = typer.Option(
+        None,
+        help="Optional upstream SGE job id dependency when using --scheduler sge.",
+    ),
+) -> None:
+    """Run or preview the QSIRecon stage."""
+    _run_stage(
+        stage=StageId.QSIRECON,
+        config=config,
+        participant=participant,
+        scheduler=scheduler,
+        dry_run=dry_run,
+        hold_jid=hold_jid,
+    )
 
 
 if __name__ == "__main__":

--- a/src/bidsflow/cli.py
+++ b/src/bidsflow/cli.py
@@ -249,7 +249,10 @@ def scheduler_accounting_sge(
     _, scheduler = _load_sge_scheduler(config)
     job_accounting = scheduler.accounting(job_id)
     if job_accounting is None:
-        console.print(f"No qacct information found for job {job_id}.")
+        console.print(
+            f"No qacct information found for job {job_id}. "
+            "Your SGE site may not have accounting enabled yet."
+        )
         raise typer.Exit(code=1)
 
     table = Table(title="SGE job accounting")

--- a/src/bidsflow/cli.py
+++ b/src/bidsflow/cli.py
@@ -65,7 +65,14 @@ def doctor(
 
 
 @config_app.command("validate")
-def config_validate(config: Path = typer.Option(..., exists=True, help="Path to TOML config.")) -> None:
+def config_validate(
+    config: Path = typer.Option(
+        ...,
+        exists=True,
+        dir_okay=False,
+        help="Path to TOML config.",
+    ),
+) -> None:
     """Validate project configuration and execution settings."""
     loaded = load_config(config)
     table = Table(title="Validated BIDSFlow config")

--- a/src/bidsflow/cli.py
+++ b/src/bidsflow/cli.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
+import shlex
+import shutil
 from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.syntax import Syntax
 from rich.table import Table
 
-from bidsflow.core.stages import STAGES
+from bidsflow.config.load import load_config
+from bidsflow.config.models import Config
+from bidsflow.core.stages import STAGES, StageId
+from bidsflow.scheduler.sge import SGECliScheduler
 
 app = typer.Typer(
     help="BIDSFlow: a staged Python CLI orchestrator for BIDS Apps.",
     no_args_is_help=True,
 )
+scheduler_app = typer.Typer(help="Scheduler planning and submission helpers.")
+app.add_typer(scheduler_app, name="scheduler")
 console = Console()
 
 
@@ -23,15 +31,52 @@ def init(path: Path = typer.Option(Path("."), help="Project root to initialize."
 
 
 @app.command()
-def doctor() -> None:
+def doctor(
+    config: Path | None = typer.Option(
+        None,
+        exists=True,
+        dir_okay=False,
+        help="Optional config path to inspect.",
+    ),
+) -> None:
     """Inspect local execution prerequisites."""
-    console.print("Doctor checks will cover Python, container backend, templates, and licenses.")
+    table = Table(title="BIDSFlow doctor")
+    table.add_column("Check")
+    table.add_column("Result")
+
+    table.add_row("python", shutil.which("python") or "not found")
+    table.add_row("qsub", shutil.which("qsub") or "not found")
+    table.add_row("qstat", shutil.which("qstat") or "not found")
+
+    if config is not None:
+        loaded = load_config(config)
+        table.add_row("config", str(config.resolve()))
+        table.add_row("backend", loaded.execution.backend)
+        table.add_row("scheduler", loaded.execution.scheduler)
+        if loaded.execution.scheduler == "sge":
+            table.add_row("sge driver", loaded.scheduler.sge.driver)
+            table.add_row("sge queue", loaded.scheduler.sge.queue or "-")
+            table.add_row("project root", str(loaded.project.root))
+
+    console.print(table)
 
 
 @app.command()
 def validate(config: Path = typer.Option(..., exists=True, help="Path to TOML config.")) -> None:
     """Validate project configuration and stage inputs."""
-    console.print(f"Validating configuration and inputs from: {config}")
+    loaded = load_config(config)
+    table = Table(title="Validated BIDSFlow config")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("config", str(config.resolve()))
+    table.add_row("project root", str(loaded.project.root))
+    table.add_row("backend", loaded.execution.backend)
+    table.add_row("scheduler", loaded.execution.scheduler)
+    if loaded.execution.scheduler == "sge":
+        table.add_row("sge driver", loaded.scheduler.sge.driver)
+        table.add_row("sge queue", loaded.scheduler.sge.queue or "-")
+        table.add_row("sge parallel env", loaded.scheduler.sge.parallel_environment or "-")
+    console.print(table)
 
 
 @app.command()
@@ -100,6 +145,134 @@ def status() -> None:
         products = ", ".join(stage.products)
         table.add_row(stage.id.value, upstream, products)
     console.print(table)
+
+
+def _load_sge_scheduler(config: Path) -> tuple[Config, SGECliScheduler]:
+    loaded = load_config(config)
+    if loaded.execution.scheduler != "sge":
+        raise typer.BadParameter(
+            f"Config scheduler is '{loaded.execution.scheduler}', expected 'sge' for this command."
+        )
+    return loaded, SGECliScheduler(loaded.scheduler.sge)
+
+
+@scheduler_app.command("plan-sge")
+def scheduler_plan_sge(
+    stage: StageId = typer.Argument(..., help="Stage id to schedule."),
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    hold_jid: str | None = typer.Option(None, help="Optional upstream SGE job id dependency."),
+    submit: bool = typer.Option(
+        False,
+        help="Submit with qsub after rendering the plan instead of only printing it.",
+    ),
+) -> None:
+    """Preview or submit an SGE qsub plan for a stage execution unit."""
+    loaded, scheduler = _load_sge_scheduler(config)
+    plan = scheduler.plan_stage_submission(
+        config_path=config,
+        config=loaded,
+        stage=stage,
+        participant=participant,
+        hold_jid=hold_jid,
+    )
+
+    table = Table(title="SGE submission plan")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("stage", stage.value)
+    table.add_row("participant", participant or "-")
+    table.add_row("job name", plan.launch.job_name)
+    table.add_row("script path", str(plan.script_path))
+    table.add_row("stdout", str(plan.launch.stdout_path))
+    table.add_row("stderr", str(plan.launch.stderr_path))
+    table.add_row("qsub", shlex.join(plan.qsub_command))
+    console.print(table)
+    console.print(Syntax(plan.script_text, "bash", theme="ansi_dark", line_numbers=True))
+
+    if submit:
+        submitted = scheduler.submit(plan)
+        console.print(f"Submitted SGE job {submitted.job_id}")
+
+
+@scheduler_app.command("status-sge")
+def scheduler_status_sge(
+    job_id: str = typer.Option(..., help="SGE job id to inspect."),
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    accounting: bool = typer.Option(
+        False,
+        help="Fall back to qacct if the job is no longer present in qstat.",
+    ),
+) -> None:
+    """Inspect the live or completed status of an SGE job."""
+    _, scheduler = _load_sge_scheduler(config)
+    job_status = scheduler.status(job_id)
+
+    if job_status is not None:
+        table = Table(title="SGE job status")
+        table.add_column("Field")
+        table.add_column("Value")
+        table.add_row("job id", job_status.job_id)
+        table.add_row("name", job_status.name)
+        table.add_row("state", job_status.state)
+        table.add_row("owner", job_status.owner or "-")
+        table.add_row("queue", job_status.queue_name or "-")
+        table.add_row("slots", str(job_status.slots) if job_status.slots is not None else "-")
+        console.print(table)
+        return
+
+    if accounting:
+        job_accounting = scheduler.accounting(job_id)
+        if job_accounting is not None:
+            table = Table(title="SGE job accounting")
+            table.add_column("Field")
+            table.add_column("Value")
+            table.add_row("job id", job_accounting.job_id)
+            table.add_row("exit status", job_accounting.exit_status or "-")
+            table.add_row("failed", job_accounting.failed or "-")
+            table.add_row("wallclock", job_accounting.wallclock or "-")
+            table.add_row("cpu", job_accounting.cpu or "-")
+            table.add_row("maxvmem", job_accounting.maxvmem or "-")
+            console.print(table)
+            return
+
+    console.print(f"No SGE status information found for job {job_id}.")
+    raise typer.Exit(code=1)
+
+
+@scheduler_app.command("accounting-sge")
+def scheduler_accounting_sge(
+    job_id: str = typer.Option(..., help="SGE job id to inspect via qacct."),
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+) -> None:
+    """Inspect qacct information for a completed SGE job."""
+    _, scheduler = _load_sge_scheduler(config)
+    job_accounting = scheduler.accounting(job_id)
+    if job_accounting is None:
+        console.print(f"No qacct information found for job {job_id}.")
+        raise typer.Exit(code=1)
+
+    table = Table(title="SGE job accounting")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("job id", job_accounting.job_id)
+    table.add_row("exit status", job_accounting.exit_status or "-")
+    table.add_row("failed", job_accounting.failed or "-")
+    table.add_row("wallclock", job_accounting.wallclock or "-")
+    table.add_row("cpu", job_accounting.cpu or "-")
+    table.add_row("maxvmem", job_accounting.maxvmem or "-")
+    console.print(table)
+
+
+@scheduler_app.command("cancel-sge")
+def scheduler_cancel_sge(
+    job_id: str = typer.Option(..., help="SGE job id to cancel."),
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+) -> None:
+    """Cancel an SGE job with qdel."""
+    _, scheduler = _load_sge_scheduler(config)
+    command = scheduler.cancel(job_id)
+    console.print(f"Ran {shlex.join(command)}")
 
 
 if __name__ == "__main__":

--- a/src/bidsflow/cli.py
+++ b/src/bidsflow/cli.py
@@ -58,7 +58,6 @@ def doctor(
         table.add_row("backend", loaded.execution.backend)
         table.add_row("scheduler", loaded.execution.scheduler)
         if loaded.execution.scheduler == "sge":
-            table.add_row("sge driver", loaded.scheduler.sge.driver)
             table.add_row("sge queue", loaded.scheduler.sge.queue or "-")
             table.add_row("project root", str(loaded.project.root))
 
@@ -77,7 +76,6 @@ def config_validate(config: Path = typer.Option(..., exists=True, help="Path to 
     table.add_row("backend", loaded.execution.backend)
     table.add_row("scheduler", loaded.execution.scheduler)
     if loaded.execution.scheduler == "sge":
-        table.add_row("sge driver", loaded.scheduler.sge.driver)
         table.add_row("sge queue", loaded.scheduler.sge.queue or "-")
         table.add_row("sge parallel env", loaded.scheduler.sge.parallel_environment or "-")
     console.print(table)

--- a/src/bidsflow/config/load.py
+++ b/src/bidsflow/config/load.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from bidsflow.config.models import Config
+import tomllib
+
+
+def _resolve_path(path: Path, base: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return (base / path).resolve()
+
+
+def load_config(path: Path) -> Config:
+    config_path = path.resolve()
+    with config_path.open("rb") as stream:
+        data = tomllib.load(stream)
+
+    config = Config.model_validate(data)
+    config_dir = config_path.parent
+
+    config.project.root = _resolve_path(config.project.root, config_dir)
+    project_root = config.project.root
+
+    config.project.bids_root = _resolve_path(config.project.bids_root, project_root)
+    config.project.derivatives_root = _resolve_path(config.project.derivatives_root, project_root)
+
+    config.execution.work_root = _resolve_path(config.execution.work_root, project_root)
+    config.execution.logs_root = _resolve_path(config.execution.logs_root, project_root)
+    config.execution.state_root = _resolve_path(config.execution.state_root, project_root)
+
+    if config.heudiconv.heuristic is not None:
+        config.heudiconv.heuristic = _resolve_path(config.heudiconv.heuristic, project_root)
+    config.heudiconv.outdir = _resolve_path(config.heudiconv.outdir, project_root)
+
+    return config

--- a/src/bidsflow/config/models.py
+++ b/src/bidsflow/config/models.py
@@ -34,7 +34,6 @@ class SGEDefaultResourcesConfig(BaseModel):
 
 
 class SGEConfig(BaseModel):
-    driver: Literal["cli", "drmaa1"] = "cli"
     queue: str | None = None
     project: str | None = None
     parallel_environment: str | None = None

--- a/src/bidsflow/scheduler/__init__.py
+++ b/src/bidsflow/scheduler/__init__.py
@@ -1,0 +1,20 @@
+"""Scheduler helpers for staged execution backends."""
+
+from bidsflow.scheduler.models import (
+    LaunchSpec,
+    SGEAccounting,
+    SGEJobStatus,
+    SGEPlannedSubmission,
+    SubmittedJob,
+)
+from bidsflow.scheduler.sge import SGECliScheduler, build_stage_launch_spec
+
+__all__ = [
+    "LaunchSpec",
+    "SGEAccounting",
+    "SGECliScheduler",
+    "SGEJobStatus",
+    "SGEPlannedSubmission",
+    "SubmittedJob",
+    "build_stage_launch_spec",
+]

--- a/src/bidsflow/scheduler/models.py
+++ b/src/bidsflow/scheduler/models.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from bidsflow.core.stages import StageId
+
+
+@dataclass(frozen=True)
+class LaunchSpec:
+    stage: StageId
+    participant: str | None
+    job_name: str
+    cwd: Path
+    command: tuple[str, ...]
+    stdout_path: Path
+    stderr_path: Path
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SGERequestedResources:
+    slots: int
+    walltime: str
+    memory: str
+    extra_requests: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SGEPlannedSubmission:
+    launch: LaunchSpec
+    resources: SGERequestedResources
+    script_path: Path
+    script_text: str
+    qsub_command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SubmittedJob:
+    job_id: str
+    script_path: Path
+    qsub_command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SGEJobStatus:
+    job_id: str
+    name: str
+    state: str
+    owner: str | None = None
+    queue_name: str | None = None
+    slots: int | None = None
+
+
+@dataclass(frozen=True)
+class SGEAccounting:
+    job_id: str
+    exit_status: str | None
+    failed: str | None
+    wallclock: str | None
+    cpu: str | None
+    maxvmem: str | None
+    raw_fields: dict[str, str] = field(default_factory=dict)

--- a/src/bidsflow/scheduler/sge.py
+++ b/src/bidsflow/scheduler/sge.py
@@ -42,6 +42,8 @@ def build_stage_launch_spec(config_path: Path, config: Config, stage: StageId, p
         stage.value,
         "--config",
         str(config_path.resolve()),
+        "--scheduler",
+        "local",
     ]
     if participant:
         command.extend(["--participant", participant])

--- a/src/bidsflow/scheduler/sge.py
+++ b/src/bidsflow/scheduler/sge.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from bidsflow.config.models import Config, SGEConfig
+from bidsflow.core.stages import STAGES, StageId
+from bidsflow.scheduler.models import (
+    LaunchSpec,
+    SGEAccounting,
+    SGEJobStatus,
+    SGEPlannedSubmission,
+    SGERequestedResources,
+    SubmittedJob,
+)
+
+
+def _slugify(value: str) -> str:
+    allowed = [char if char.isalnum() or char in {"-", "_", "."} else "-" for char in value]
+    normalized = "".join(allowed).strip("-")
+    return normalized or "job"
+
+
+def build_stage_launch_spec(config_path: Path, config: Config, stage: StageId, participant: str | None) -> LaunchSpec:
+    log_dir = config.execution.logs_root / "sge" / stage.value
+    job_name_parts = ["bidsflow", stage.value]
+    if participant:
+        job_name_parts.append(participant)
+    job_name = _slugify("-".join(job_name_parts))
+
+    stdout_path = log_dir / f"{job_name}.out"
+    stderr_path = log_dir / f"{job_name}.err"
+
+    command = [
+        sys.executable,
+        "-m",
+        "bidsflow.cli",
+        stage.value,
+        "--config",
+        str(config_path.resolve()),
+    ]
+    if participant:
+        command.extend(["--participant", participant])
+
+    return LaunchSpec(
+        stage=stage,
+        participant=participant,
+        job_name=job_name,
+        cwd=config.project.root,
+        command=tuple(command),
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+
+
+class SGECliScheduler:
+    def __init__(self, config: SGEConfig) -> None:
+        self.config = config
+
+    @staticmethod
+    def _require_command(name: str) -> None:
+        if shutil.which(name) is None:
+            raise RuntimeError(f"{name} is not available in PATH for SGE operations.")
+
+    @staticmethod
+    def _run_command(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def requested_resources(self) -> SGERequestedResources:
+        defaults = self.config.default_resources
+        return SGERequestedResources(
+            slots=defaults.slots,
+            walltime=defaults.walltime,
+            memory=defaults.memory,
+            extra_requests=dict(self.config.extra_requests),
+        )
+
+    def plan_stage_submission(
+        self,
+        *,
+        config_path: Path,
+        config: Config,
+        stage: StageId,
+        participant: str | None,
+        hold_jid: str | None = None,
+    ) -> SGEPlannedSubmission:
+        launch = build_stage_launch_spec(config_path=config_path, config=config, stage=stage, participant=participant)
+        resources = self.requested_resources()
+        script_path = config.execution.state_root / "sge" / f"{launch.job_name}.sh"
+        script_text = self.render_script(launch)
+        qsub_command = self.build_qsub_command(
+            launch=launch,
+            resources=resources,
+            script_path=script_path,
+            hold_jid=hold_jid,
+        )
+        return SGEPlannedSubmission(
+            launch=launch,
+            resources=resources,
+            script_path=script_path,
+            script_text=script_text,
+            qsub_command=qsub_command,
+        )
+
+    def render_script(self, launch: LaunchSpec) -> str:
+        lines = [
+            "#!/bin/bash",
+            "set -euo pipefail",
+            f"cd {shlex.quote(str(launch.cwd))}",
+        ]
+        for key, value in sorted(launch.env.items()):
+            lines.append(f"export {key}={shlex.quote(value)}")
+        lines.append(f"exec {shlex.join(launch.command)}")
+        return "\n".join(lines) + "\n"
+
+    def build_qsub_command(
+        self,
+        *,
+        launch: LaunchSpec,
+        resources: SGERequestedResources,
+        script_path: Path,
+        hold_jid: str | None = None,
+    ) -> tuple[str, ...]:
+        command: list[str] = [
+            "qsub",
+            "-terse",
+            "-N",
+            launch.job_name,
+            "-o",
+            str(launch.stdout_path),
+            "-e",
+            str(launch.stderr_path),
+        ]
+
+        if self.config.inherit_cwd:
+            command.append("-cwd")
+        if self.config.export_env:
+            command.append("-V")
+        if self.config.queue:
+            command.extend(["-q", self.config.queue])
+        if self.config.project:
+            command.extend(["-P", self.config.project])
+        if self.config.parallel_environment:
+            command.extend(["-pe", self.config.parallel_environment, str(resources.slots)])
+        if hold_jid:
+            command.extend(["-hold_jid", hold_jid])
+
+        resource_specs = [
+            f"{self.config.resource_map.walltime}={resources.walltime}",
+            f"{self.config.resource_map.memory}={resources.memory}",
+        ]
+        resource_specs.extend(f"{key}={value}" for key, value in sorted(resources.extra_requests.items()))
+        command.extend(["-l", ",".join(resource_specs)])
+        command.append(str(script_path))
+        return tuple(command)
+
+    def write_script(self, plan: SGEPlannedSubmission) -> None:
+        plan.launch.stdout_path.parent.mkdir(parents=True, exist_ok=True)
+        plan.launch.stderr_path.parent.mkdir(parents=True, exist_ok=True)
+        plan.script_path.parent.mkdir(parents=True, exist_ok=True)
+        plan.script_path.write_text(plan.script_text, encoding="utf-8")
+
+    def submit(self, plan: SGEPlannedSubmission) -> SubmittedJob:
+        self._require_command("qsub")
+        self.write_script(plan)
+        completed = self._run_command(plan.qsub_command)
+        job_id = self.parse_job_id(completed.stdout)
+        return SubmittedJob(
+            job_id=job_id,
+            script_path=plan.script_path,
+            qsub_command=plan.qsub_command,
+        )
+
+    def build_qdel_command(self, job_id: str) -> tuple[str, ...]:
+        return ("qdel", job_id)
+
+    def build_qstat_command(self) -> tuple[str, ...]:
+        return ("qstat", "-xml")
+
+    def build_qacct_command(self, job_id: str) -> tuple[str, ...]:
+        return ("qacct", "-j", job_id)
+
+    def cancel(self, job_id: str) -> tuple[str, ...]:
+        self._require_command("qdel")
+        command = self.build_qdel_command(job_id)
+        self._run_command(command)
+        return command
+
+    def status(self, job_id: str) -> SGEJobStatus | None:
+        self._require_command("qstat")
+        completed = self._run_command(self.build_qstat_command())
+        return self.parse_qstat_xml(completed.stdout, job_id=job_id)
+
+    def accounting(self, job_id: str) -> SGEAccounting | None:
+        self._require_command("qacct")
+        completed = self._run_command(self.build_qacct_command(job_id))
+        return self.parse_qacct_output(completed.stdout, job_id=job_id)
+
+    @staticmethod
+    def parse_job_id(output: str) -> str:
+        stripped = output.strip()
+        if not stripped:
+            raise ValueError("qsub output did not contain a job id.")
+        return stripped.split()[0]
+
+    @staticmethod
+    def parse_qstat_xml(output: str, *, job_id: str) -> SGEJobStatus | None:
+        root = ET.fromstring(output)
+        for job in root.findall(".//job_list"):
+            parsed_job_id = (job.findtext("JB_job_number") or "").strip()
+            if parsed_job_id != job_id:
+                continue
+            slots_text = (job.findtext("slots") or "").strip()
+            slots = int(slots_text) if slots_text.isdigit() else None
+            return SGEJobStatus(
+                job_id=parsed_job_id,
+                name=(job.findtext("JB_name") or "").strip(),
+                state=(job.findtext("state") or "").strip(),
+                owner=(job.findtext("JB_owner") or "").strip() or None,
+                queue_name=(job.findtext("queue_name") or "").strip() or None,
+                slots=slots,
+            )
+        return None
+
+    @staticmethod
+    def parse_qacct_output(output: str, *, job_id: str) -> SGEAccounting | None:
+        stripped = output.strip()
+        lowered = stripped.lower()
+        if not stripped or "not found" in lowered:
+            return None
+
+        fields: dict[str, str] = {}
+        for line in stripped.splitlines():
+            if not line.strip():
+                continue
+            if line.startswith("==="):
+                continue
+            parts = line.split(None, 1)
+            if len(parts) != 2:
+                continue
+            key, value = parts
+            fields[key] = value.strip()
+
+        if not fields:
+            return None
+
+        return SGEAccounting(
+            job_id=fields.get("jobnumber", job_id),
+            exit_status=fields.get("exit_status"),
+            failed=fields.get("failed"),
+            wallclock=fields.get("ru_wallclock"),
+            cpu=fields.get("cpu"),
+            maxvmem=fields.get("maxvmem"),
+            raw_fields=fields,
+        )
+
+
+def build_stage_choices() -> tuple[StageId, ...]:
+    return tuple(STAGES.keys())

--- a/src/bidsflow/scheduler/sge.py
+++ b/src/bidsflow/scheduler/sge.py
@@ -202,7 +202,14 @@ class SGECliScheduler:
 
     def accounting(self, job_id: str) -> SGEAccounting | None:
         self._require_command("qacct")
-        completed = self._run_command(self.build_qacct_command(job_id))
+        try:
+            completed = self._run_command(self.build_qacct_command(job_id))
+        except subprocess.CalledProcessError as error:
+            stderr = (error.stderr or "").strip().lower()
+            stdout = (error.stdout or "").strip().lower()
+            if "no jobs running since startup" in stdout or "no such file or directory" in stderr:
+                return None
+            raise
         return self.parse_qacct_output(completed.stdout, job_id=job_id)
 
     @staticmethod

--- a/src/bidsflow/scheduler/sge.py
+++ b/src/bidsflow/scheduler/sge.py
@@ -113,8 +113,8 @@ class SGECliScheduler:
 
     def render_script(self, launch: LaunchSpec) -> str:
         lines = [
-            "#!/bin/bash",
-            "set -euo pipefail",
+            "#!/bin/sh",
+            "set -eu",
             f"cd {shlex.quote(str(launch.cwd))}",
         ]
         for key, value in sorted(launch.env.items()):

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from bidsflow.config.load import load_config
+
+
+def test_load_config_resolves_paths_relative_to_project_root() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config = load_config(repo_root / "examples" / "project.toml")
+
+    assert config.execution.scheduler == "sge"
+    assert config.project.root == repo_root
+    assert config.execution.logs_root == repo_root / "logs"
+    assert config.execution.state_root == repo_root / "state"
+    assert config.heudiconv.heuristic == repo_root / "code" / "heuristics" / "heuristic.py"

--- a/tests/test_scheduler_sge.py
+++ b/tests/test_scheduler_sge.py
@@ -232,3 +232,30 @@ def test_scheduler_status_and_accounting_cli_commands(monkeypatch) -> None:
 
     assert cancel_result.exit_code == 0
     assert "qdel 12345" in cancel_result.stdout
+
+
+def test_scheduler_accounting_cli_handles_missing_qacct(monkeypatch) -> None:
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+
+    monkeypatch.setattr(
+        "bidsflow.scheduler.sge.SGECliScheduler.accounting",
+        lambda self, job_id: None,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "scheduler",
+            "accounting-sge",
+            "--job-id",
+            "12345",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "accounting" in result.stdout
+    assert "enabled yet" in result.stdout

--- a/tests/test_scheduler_sge.py
+++ b/tests/test_scheduler_sge.py
@@ -196,6 +196,16 @@ def test_config_validate_command_uses_new_namespace() -> None:
     assert "scheduler" in result.stdout
 
 
+def test_config_validate_rejects_directories() -> None:
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = runner.invoke(app, ["config", "validate", "--config", str(repo_root)])
+
+    assert result.exit_code == 2
+    assert isinstance(result.exception, SystemExit)
+
+
 def test_stage_dry_run_uses_configured_sge_scheduler() -> None:
     runner = CliRunner()
     repo_root = Path(__file__).resolve().parents[1]

--- a/tests/test_scheduler_sge.py
+++ b/tests/test_scheduler_sge.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 from bidsflow.cli import app
 from bidsflow.config.load import load_config
 from bidsflow.core.stages import StageId
-from bidsflow.scheduler.models import SGEAccounting, SGEJobStatus
+from bidsflow.scheduler.models import SubmittedJob
 from bidsflow.scheduler.sge import SGECliScheduler
 
 
@@ -48,6 +48,7 @@ def test_plan_stage_submission_renders_qsub_command_and_script() -> None:
     assert "set -eu" in plan.script_text
     assert "bidsflow.cli fmriprep --config" in plan.script_text
     assert "--participant sub-001" in plan.script_text
+    assert "--scheduler local" in plan.script_text
 
 
 def test_parse_job_id_uses_first_token() -> None:
@@ -107,6 +108,33 @@ def test_parse_qacct_output_extracts_accounting() -> None:
     assert accounting.maxvmem == "31.500G"
 
 
+def test_accounting_returns_none_when_site_accounting_is_unavailable(monkeypatch) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+    config = load_config(config_path)
+    scheduler = SGECliScheduler(config.scheduler.sge)
+
+    monkeypatch.setattr("bidsflow.scheduler.sge.shutil.which", lambda _: "/usr/bin/mock")
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            1,
+            command,
+            output="no jobs running since startup\n",
+            stderr="/var/lib/gridengine/common/accounting: No such file or directory\n",
+        )
+
+    monkeypatch.setattr("bidsflow.scheduler.sge.subprocess.run", fake_run)
+
+    assert scheduler.accounting("12345") is None
+
+
 def test_submit_and_cancel_use_external_commands(monkeypatch, tmp_path: Path) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     config_path = repo_root / "examples" / "project.toml"
@@ -156,106 +184,107 @@ def test_submit_and_cancel_use_external_commands(monkeypatch, tmp_path: Path) ->
     assert commands[1] == cancel_command
 
 
-def test_scheduler_status_and_accounting_cli_commands(monkeypatch) -> None:
+def test_config_validate_command_uses_new_namespace() -> None:
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+
+    result = runner.invoke(app, ["config", "validate", "--config", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "Validated BIDSFlow config" in result.stdout
+    assert "scheduler" in result.stdout
+
+
+def test_stage_dry_run_uses_configured_sge_scheduler() -> None:
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+
+    result = runner.invoke(
+        app,
+        [
+            "fmriprep",
+            "--config",
+            str(config_path),
+            "--participant",
+            "sub-001",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "SGE stage run preview" in result.stdout
+    assert "qsub" in result.stdout
+    assert "--scheduler local" in result.stdout
+
+
+def test_stage_run_submits_sge_job_from_config(monkeypatch) -> None:
     runner = CliRunner()
     repo_root = Path(__file__).resolve().parents[1]
     config_path = repo_root / "examples" / "project.toml"
 
     monkeypatch.setattr(
-        "bidsflow.scheduler.sge.SGECliScheduler.status",
-        lambda self, job_id: SGEJobStatus(
-            job_id=job_id,
-            name="bidsflow-fmriprep-sub-001",
-            state="r",
-            owner="liang",
-            queue_name="all.q@node01",
-            slots=8,
+        "bidsflow.scheduler.sge.SGECliScheduler.submit",
+        lambda self, plan: SubmittedJob(
+            job_id="12345.cluster.example",
+            script_path=plan.script_path,
+            qsub_command=plan.qsub_command,
         ),
-    )
-    monkeypatch.setattr(
-        "bidsflow.scheduler.sge.SGECliScheduler.accounting",
-        lambda self, job_id: SGEAccounting(
-            job_id=job_id,
-            exit_status="0",
-            failed="0",
-            wallclock="3600",
-            cpu="120.500",
-            maxvmem="31.500G",
-        ),
-    )
-    monkeypatch.setattr(
-        "bidsflow.scheduler.sge.SGECliScheduler.cancel",
-        lambda self, job_id: ("qdel", job_id),
-    )
-
-    status_result = runner.invoke(
-        app,
-        [
-            "scheduler",
-            "status-sge",
-            "--job-id",
-            "12345",
-            "--config",
-            str(config_path),
-        ],
-    )
-    accounting_result = runner.invoke(
-        app,
-        [
-            "scheduler",
-            "accounting-sge",
-            "--job-id",
-            "12345",
-            "--config",
-            str(config_path),
-        ],
-    )
-    cancel_result = runner.invoke(
-        app,
-        [
-            "scheduler",
-            "cancel-sge",
-            "--job-id",
-            "12345",
-            "--config",
-            str(config_path),
-        ],
-    )
-
-    assert status_result.exit_code == 0
-    assert "SGE job status" in status_result.stdout
-    assert "bidsflow-fmriprep-sub-001" in status_result.stdout
-
-    assert accounting_result.exit_code == 0
-    assert "SGE job accounting" in accounting_result.stdout
-    assert "31.500G" in accounting_result.stdout
-
-    assert cancel_result.exit_code == 0
-    assert "qdel 12345" in cancel_result.stdout
-
-
-def test_scheduler_accounting_cli_handles_missing_qacct(monkeypatch) -> None:
-    runner = CliRunner()
-    repo_root = Path(__file__).resolve().parents[1]
-    config_path = repo_root / "examples" / "project.toml"
-
-    monkeypatch.setattr(
-        "bidsflow.scheduler.sge.SGECliScheduler.accounting",
-        lambda self, job_id: None,
     )
 
     result = runner.invoke(
         app,
         [
-            "scheduler",
-            "accounting-sge",
-            "--job-id",
-            "12345",
+            "fmriprep",
             "--config",
             str(config_path),
+            "--participant",
+            "sub-001",
         ],
     )
 
-    assert result.exit_code == 1
-    assert "accounting" in result.stdout
-    assert "enabled yet" in result.stdout
+    assert result.exit_code == 0
+    assert "Submitted SGE job 12345.cluster.example" in result.stdout
+
+
+def test_stage_run_supports_local_scheduler_override() -> None:
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+
+    result = runner.invoke(
+        app,
+        [
+            "fmriprep",
+            "--config",
+            str(config_path),
+            "--participant",
+            "sub-001",
+            "--scheduler",
+            "local",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "fMRIPrep stage requested" in result.stdout
+
+
+def test_validate_stage_rejects_participant_argument() -> None:
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+
+    result = runner.invoke(
+        app,
+        [
+            "validate",
+            "--config",
+            str(config_path),
+            "--participant",
+            "sub-001",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "does not accept --participant" in result.stdout

--- a/tests/test_scheduler_sge.py
+++ b/tests/test_scheduler_sge.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+from typer.testing import CliRunner
+
+from bidsflow.cli import app
+from bidsflow.config.load import load_config
+from bidsflow.core.stages import StageId
+from bidsflow.scheduler.models import SGEAccounting, SGEJobStatus
+from bidsflow.scheduler.sge import SGECliScheduler
+
+
+def test_plan_stage_submission_renders_qsub_command_and_script() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+    config = load_config(config_path)
+
+    scheduler = SGECliScheduler(config.scheduler.sge)
+    plan = scheduler.plan_stage_submission(
+        config_path=config_path,
+        config=config,
+        stage=StageId.FMRIPREP,
+        participant="sub-001",
+        hold_jid="1234",
+    )
+
+    assert plan.launch.job_name == "bidsflow-fmriprep-sub-001"
+    assert plan.script_path.name == "bidsflow-fmriprep-sub-001.sh"
+    assert plan.launch.stdout_path.name == "bidsflow-fmriprep-sub-001.out"
+    assert plan.launch.stderr_path.name == "bidsflow-fmriprep-sub-001.err"
+
+    assert plan.qsub_command[:4] == ("qsub", "-terse", "-N", "bidsflow-fmriprep-sub-001")
+    assert "-cwd" in plan.qsub_command
+    assert "-q" in plan.qsub_command
+    assert "all.q" in plan.qsub_command
+    assert "-P" in plan.qsub_command
+    assert "neuro" in plan.qsub_command
+    assert "-pe" in plan.qsub_command
+    assert "smp" in plan.qsub_command
+    assert "-hold_jid" in plan.qsub_command
+    assert "1234" in plan.qsub_command
+
+    resources = plan.qsub_command[plan.qsub_command.index("-l") + 1]
+    assert "h_rt=24:00:00" in resources
+    assert "h_vmem=32G" in resources
+    assert "tmp_free=20G" in resources
+
+    assert "set -euo pipefail" in plan.script_text
+    assert "bidsflow.cli fmriprep --config" in plan.script_text
+    assert "--participant sub-001" in plan.script_text
+
+
+def test_parse_job_id_uses_first_token() -> None:
+    job_id = SGECliScheduler.parse_job_id("12345.cluster.example\n")
+    assert job_id == "12345.cluster.example"
+
+
+def test_parse_qstat_xml_extracts_job_status() -> None:
+    xml_text = """
+    <job_info>
+      <queue_info>
+        <job_list state="running">
+          <JB_job_number>12345</JB_job_number>
+          <JB_name>bidsflow-fmriprep-sub-001</JB_name>
+          <JB_owner>liang</JB_owner>
+          <state>r</state>
+          <queue_name>all.q@node01</queue_name>
+          <slots>8</slots>
+        </job_list>
+      </queue_info>
+    </job_info>
+    """
+
+    status = SGECliScheduler.parse_qstat_xml(xml_text, job_id="12345")
+
+    assert status is not None
+    assert status.job_id == "12345"
+    assert status.name == "bidsflow-fmriprep-sub-001"
+    assert status.owner == "liang"
+    assert status.state == "r"
+    assert status.queue_name == "all.q@node01"
+    assert status.slots == 8
+
+
+def test_parse_qacct_output_extracts_accounting() -> None:
+    qacct_text = """
+    ==============================================================
+    qname        all.q
+    hostname     node01
+    jobname      bidsflow-fmriprep-sub-001
+    jobnumber    12345
+    failed       0
+    exit_status  0
+    ru_wallclock 3600
+    cpu          120.500
+    maxvmem      31.500G
+    """
+
+    accounting = SGECliScheduler.parse_qacct_output(qacct_text, job_id="12345")
+
+    assert accounting is not None
+    assert accounting.job_id == "12345"
+    assert accounting.failed == "0"
+    assert accounting.exit_status == "0"
+    assert accounting.wallclock == "3600"
+    assert accounting.cpu == "120.500"
+    assert accounting.maxvmem == "31.500G"
+
+
+def test_submit_and_cancel_use_external_commands(monkeypatch, tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+    config = load_config(config_path)
+    scheduler = SGECliScheduler(config.scheduler.sge)
+    plan = scheduler.plan_stage_submission(
+        config_path=config_path,
+        config=config,
+        stage=StageId.FMRIPREP,
+        participant="sub-001",
+    )
+    plan = type(plan)(
+        launch=plan.launch,
+        resources=plan.resources,
+        script_path=tmp_path / plan.script_path.name,
+        script_text=plan.script_text,
+        qsub_command=tuple(
+            str(tmp_path / plan.script_path.name) if item == str(plan.script_path) else item
+            for item in plan.qsub_command
+        ),
+    )
+
+    monkeypatch.setattr("bidsflow.scheduler.sge.shutil.which", lambda _: "/usr/bin/mock")
+
+    commands: list[tuple[str, ...]] = []
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        stdout = "12345.cluster.example\n" if command[0] == "qsub" else ""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("bidsflow.scheduler.sge.subprocess.run", fake_run)
+
+    submitted = scheduler.submit(plan)
+    cancel_command = scheduler.cancel("12345.cluster.example")
+
+    assert submitted.job_id == "12345.cluster.example"
+    assert plan.script_path.exists()
+    assert commands[0][0] == "qsub"
+    assert cancel_command == ("qdel", "12345.cluster.example")
+    assert commands[1] == cancel_command
+
+
+def test_scheduler_status_and_accounting_cli_commands(monkeypatch) -> None:
+    runner = CliRunner()
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "examples" / "project.toml"
+
+    monkeypatch.setattr(
+        "bidsflow.scheduler.sge.SGECliScheduler.status",
+        lambda self, job_id: SGEJobStatus(
+            job_id=job_id,
+            name="bidsflow-fmriprep-sub-001",
+            state="r",
+            owner="liang",
+            queue_name="all.q@node01",
+            slots=8,
+        ),
+    )
+    monkeypatch.setattr(
+        "bidsflow.scheduler.sge.SGECliScheduler.accounting",
+        lambda self, job_id: SGEAccounting(
+            job_id=job_id,
+            exit_status="0",
+            failed="0",
+            wallclock="3600",
+            cpu="120.500",
+            maxvmem="31.500G",
+        ),
+    )
+    monkeypatch.setattr(
+        "bidsflow.scheduler.sge.SGECliScheduler.cancel",
+        lambda self, job_id: ("qdel", job_id),
+    )
+
+    status_result = runner.invoke(
+        app,
+        [
+            "scheduler",
+            "status-sge",
+            "--job-id",
+            "12345",
+            "--config",
+            str(config_path),
+        ],
+    )
+    accounting_result = runner.invoke(
+        app,
+        [
+            "scheduler",
+            "accounting-sge",
+            "--job-id",
+            "12345",
+            "--config",
+            str(config_path),
+        ],
+    )
+    cancel_result = runner.invoke(
+        app,
+        [
+            "scheduler",
+            "cancel-sge",
+            "--job-id",
+            "12345",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert status_result.exit_code == 0
+    assert "SGE job status" in status_result.stdout
+    assert "bidsflow-fmriprep-sub-001" in status_result.stdout
+
+    assert accounting_result.exit_code == 0
+    assert "SGE job accounting" in accounting_result.stdout
+    assert "31.500G" in accounting_result.stdout
+
+    assert cancel_result.exit_code == 0
+    assert "qdel 12345" in cancel_result.stdout

--- a/tests/test_scheduler_sge.py
+++ b/tests/test_scheduler_sge.py
@@ -44,7 +44,8 @@ def test_plan_stage_submission_renders_qsub_command_and_script() -> None:
     assert "h_rt=00:10:00" in resources
     assert "mem_free=1G" in resources
 
-    assert "set -euo pipefail" in plan.script_text
+    assert "#!/bin/sh" in plan.script_text
+    assert "set -eu" in plan.script_text
     assert "bidsflow.cli fmriprep --config" in plan.script_text
     assert "--participant sub-001" in plan.script_text
 

--- a/tests/test_scheduler_sge.py
+++ b/tests/test_scheduler_sge.py
@@ -34,18 +34,15 @@ def test_plan_stage_submission_renders_qsub_command_and_script() -> None:
     assert plan.qsub_command[:4] == ("qsub", "-terse", "-N", "bidsflow-fmriprep-sub-001")
     assert "-cwd" in plan.qsub_command
     assert "-q" in plan.qsub_command
-    assert "all.q" in plan.qsub_command
-    assert "-P" in plan.qsub_command
-    assert "neuro" in plan.qsub_command
-    assert "-pe" in plan.qsub_command
-    assert "smp" in plan.qsub_command
+    assert "short.q" in plan.qsub_command
+    assert "-P" not in plan.qsub_command
+    assert "-pe" not in plan.qsub_command
     assert "-hold_jid" in plan.qsub_command
     assert "1234" in plan.qsub_command
 
     resources = plan.qsub_command[plan.qsub_command.index("-l") + 1]
-    assert "h_rt=24:00:00" in resources
-    assert "h_vmem=32G" in resources
-    assert "tmp_free=20G" in resources
+    assert "h_rt=00:10:00" in resources
+    assert "mem_free=1G" in resources
 
     assert "set -euo pipefail" in plan.script_text
     assert "bidsflow.cli fmriprep --config" in plan.script_text


### PR DESCRIPTION
## Summary
- add config loading and path normalization for project TOML files
- add a conservative SGE/SoGE execution skeleton with qsub script rendering and submit support
- refactor the CLI around stage-first execution: `bidsflow <stage> --scheduler ... [--dry-run]`
- move config validation to `bidsflow config validate`
- improve qacct fallback behavior for sites without accounting enabled
- add coverage reporting with Codecov and README badges for CI and coverage
- update docs, examples, and CI checks to match the new CLI shape

## Notes
- SGE job lifecycle commands (`status`, `cancel`, `accounting`) are deferred to [#2](https://github.com/psychelzh/BIDSFlow/issues/2) so stage commands can stay focused on execution.
- The current stage implementations are still lightweight placeholders; this PR is mainly about the execution skeleton and CLI shape.
- The Codecov upload is currently configured as non-blocking (`fail_ci_if_error: false`) so the workflow remains green while the repository is being enabled in Codecov.

## Validation
- `python -m pytest --cov=src/bidsflow --cov-report=xml --cov-report=term-missing`
- `python -m mypy src`
- `python -m ruff check .`
- `npx markdownlint-cli "README.md" "docs/**/*.md" ".codex/skills/**/*.md"`
- `python -m bidsflow.cli --help`
- `python -m bidsflow.cli fmriprep --help`
- `python -m bidsflow.cli config validate --help`