### PR TITLE
Draft: implement HeuDiConv stage and stage-level CLI/config conventions

### DIFF
--- a/.codex/skills/bids-app-command-builder/SKILL.md
+++ b/.codex/skills/bids-app-command-builder/SKILL.md
@@ -15,6 +15,8 @@ Start by reading these files:
 - `src/bidsflow/core/stages.py`
 - `src/bidsflow/config/models.py`
 - `src/bidsflow/cli.py`
+- `docs/design/cli-conventions.md`
+- `docs/design/heudiconv-workflow.md`
 - `docs/design/stage-model.md`
 - `docs/design/handoff-contract.md`
 
@@ -26,9 +28,10 @@ construction.
 Keep the launch pipeline separated into layers:
 
 1. normalized project and stage inputs
-2. tool-specific argument construction
-3. backend wrapping for native, Docker, or Apptainer
-4. scheduler submission handled elsewhere
+2. scope discovery and normalization
+3. tool-specific argument construction
+4. backend wrapping for native, Docker, or Apptainer
+5. scheduler submission handled elsewhere
 
 Return structured launch data whenever possible:
 
@@ -42,6 +45,8 @@ Keep the scheduler out of this layer:
 - do not embed `sbatch` logic into BIDS App argument builders
 - do not let SLURM resource keys leak into tool argument mapping
 - let the scheduler consume a launch spec produced here
+- keep user-facing command naming and subcommand semantics outside the
+  tool argv builder
 
 ## Tool-Specific Guidance
 
@@ -50,7 +55,7 @@ tool clearly supports broader batching.
 
 Preserve stage semantics:
 
-- `curate` should map to HeuDiConv-oriented inputs and curation outputs
+- `heudiconv` should map to HeuDiConv-oriented inputs and curation outputs
 - `fmriprep` should consume validated raw BIDS and emit derivative roots
 - `xcpd` should consume derivative outputs and selected downstream scope
 

--- a/.codex/skills/bids-app-command-builder/references/tool-mapping.md
+++ b/.codex/skills/bids-app-command-builder/references/tool-mapping.md
@@ -25,8 +25,7 @@ The command builder should own the middle two layers only.
 - `xcpd`: downstream derivative processing from compatible fMRIPrep
   outputs
 
-The current scaffold may still expose `curate`, but the intended
-user-facing command name is `heudiconv`.
+The intended user-facing command name is `heudiconv`.
 
 Future stages should follow the same pattern.
 

--- a/.codex/skills/bids-app-command-builder/references/tool-mapping.md
+++ b/.codex/skills/bids-app-command-builder/references/tool-mapping.md
@@ -10,6 +10,7 @@ into runnable commands.
 Keep these concerns separate:
 
 - stage contract and required inputs
+- scope discovery and normalization
 - tool-specific flags
 - backend wrapping
 - scheduler submission
@@ -18,11 +19,14 @@ The command builder should own the middle two layers only.
 
 ## Stage Anchors
 
-- `curate`: HeuDiConv-backed curation into raw BIDS
+- `heudiconv`: HeuDiConv-backed curation into raw BIDS
 - `validate`: validation and preflight logic, not a heavy executor
 - `fmriprep`: preprocessing from raw BIDS to derivatives
 - `xcpd`: downstream derivative processing from compatible fMRIPrep
   outputs
+
+The current scaffold may still expose `curate`, but the intended
+user-facing command name is `heudiconv`.
 
 Future stages should follow the same pattern.
 
@@ -51,5 +55,6 @@ Always preserve:
 - Prefer one participant per heavy app invocation.
 - Treat session and task filters as part of the scope, not ad hoc
   string fragments.
+- Resolve scope units before building argv for the underlying tool.
 - Make output and work directories explicit in the launch spec.
 - Keep command construction deterministic for the same normalized input.

--- a/.codex/skills/project-config-schema/SKILL.md
+++ b/.codex/skills/project-config-schema/SKILL.md
@@ -15,6 +15,8 @@ Start by reading these files:
 - `src/bidsflow/config/models.py`
 - `examples/project.toml`
 - `README.md`
+- `docs/design/config-strategy.md`
+- `docs/design/cli-conventions.md`
 - `docs/design/stage-model.md`
 - `docs/design/handoff-contract.md`
 
@@ -34,6 +36,10 @@ Keep the schema explicit and typed:
 - prefer `Path`, `Literal`, and bounded numeric fields over free-form strings
 - group settings by concern: project, execution, then per-stage sections
 - keep stage-specific settings inside the matching stage block
+- treat the root TOML as project defaults, not as a mandatory prerequisite
+  for every command
+- prefer references to external tool-native files over embedding complex
+  native content directly in TOML
 - avoid adding loosely typed `dict` escape hatches unless there is no
   stable alternative
 

--- a/.codex/skills/project-config-schema/references/schema-rules.md
+++ b/.codex/skills/project-config-schema/references/schema-rules.md
@@ -10,6 +10,8 @@ Current public anchors:
 - `src/bidsflow/config/models.py`
 - `examples/project.toml`
 - `README.md`
+- `docs/design/config-strategy.md`
+- `docs/design/cli-conventions.md`
 - stage and handoff design docs under `docs/design/`
 
 ## Naming Rules
@@ -20,6 +22,8 @@ Current public anchors:
 - Use one name per concept across TOML, Python, and docs.
 - Prefer `*_root` for directory roots and `*_path` for individual files.
 - Prefer positive, concrete names over abstract toggles.
+- Keep project-default config names distinct from invocation-only CLI
+  flags such as scope selectors.
 
 ## Compatibility Rules
 
@@ -30,6 +34,8 @@ Current public anchors:
 - Do not let examples drift from the actual models.
 - Keep future cluster settings under execution or backend-specific
   sections unless a stronger boundary emerges.
+- Do not force new config keys to exist for commands that are intended
+  to remain config-optional.
 
 ## Modeling Rules
 
@@ -37,6 +43,8 @@ Current public anchors:
 - Prefer `Literal` when the value set is intentionally closed.
 - Use `Path` for filesystem paths instead of raw strings.
 - Keep stage-specific models small and focused on the stage contract.
+- Prefer one root project config plus references to external
+  tool-specific artifacts over mirroring an entire upstream CLI.
 - Avoid hidden inference that makes generated commands hard to predict.
 
 ## Change Checklist

--- a/README.md
+++ b/README.md
@@ -136,10 +136,18 @@ implementation milestones should focus on:
 5. stage-specific command builders
 6. state tracking and resumability
 
+The CLI and configuration refinements discussed for the next
+implementation round are captured in the design docs linked below. Some
+of those docs are intentionally future-facing and may differ from the
+current scaffolded command names.
+
 ## Design documents
 
 - [Stage model](docs/design/stage-model.md)
 - [Handoff contract](docs/design/handoff-contract.md)
+- [CLI conventions](docs/design/cli-conventions.md)
+- [Configuration strategy](docs/design/config-strategy.md)
+- [HeuDiConv workflow](docs/design/heudiconv-workflow.md)
 - [SGE site configuration](docs/setup/sge-site-config.md)
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ around them:
 4. **Containers first**
    Docker and Apptainer/Singularity should be first-class backends.
 5. **Subject-level execution and recovery**
-   The natural execution unit is typically `participant × stage`.
+   The natural execution unit is typically `subject × stage`.
 
 ## Non-goals
 
@@ -64,7 +64,9 @@ At the current stage, BIDSFlow is **not** intended to:
 bidsflow init
 bidsflow doctor
 bidsflow config validate
-bidsflow curate
+bidsflow heudiconv bootstrap
+bidsflow heudiconv check
+bidsflow heudiconv run
 bidsflow validate
 bidsflow fmriprep
 bidsflow mriqc
@@ -98,18 +100,25 @@ BIDSFlow/
 │     │  └─ models.py
 │     ├─ core/
 │        └─ stages.py
+│     ├─ stages/
+│     │  ├─ __init__.py
+│     │  └─ heudiconv.py
 │     └─ scheduler/
 │        ├─ __init__.py
 │        ├─ models.py
 │        └─ sge.py
 ├─ docs/
 │  └─ design/
+│     ├─ cli-conventions.md
+│     ├─ config-strategy.md
+│     ├─ heudiconv-workflow.md
 │     ├─ stage-model.md
 │     └─ handoff-contract.md
 ├─ examples/
 │  └─ project.toml
 ├─ tests/
 │  ├─ test_config_load.py
+│  ├─ test_heudiconv.py
 │  └─ test_scheduler_sge.py
 ├─ .codex/
 │  └─ skills/
@@ -124,22 +133,22 @@ BIDSFlow/
 ## Current development status
 
 This scaffold establishes the **project boundary**, **stage model**,
-**handoff contract**, and a **minimal CLI skeleton**. The current SGE
-work also includes config loading plus stage-level `--dry-run` preview
-and submission through the configured scheduler. The next
-implementation milestones should focus on:
+**handoff contract**, a working **HeuDiConv stage**, and a still-evolving
+CLI surface for the remaining stages. The current SGE work also
+includes config loading plus stage-level `--dry-run` preview and
+submission through the configured scheduler. The next implementation
+milestones should focus on:
 
 1. configuration parsing and normalization
 2. stage registry and dependency validation
 3. scheduler runners (SGE first, SLURM later)
 4. backend runners (Docker, Apptainer, native)
-5. stage-specific command builders
+5. stage-specific command builders beyond HeuDiConv
 6. state tracking and resumability
 
-The CLI and configuration refinements discussed for the next
-implementation round are captured in the design docs linked below. Some
-of those docs are intentionally future-facing and may differ from the
-current scaffolded command names.
+The design docs linked below capture both the implemented HeuDiConv
+workflow and the broader conventions intended to guide later stage
+implementation.
 
 ## Design documents
 
@@ -164,9 +173,13 @@ bidsflow --help
 bidsflow init --path .
 bidsflow doctor
 bidsflow config validate --config examples/project.toml
-bidsflow fmriprep \
+bidsflow heudiconv check \
   --config examples/project.toml \
-  --participant sub-001 \
+  --subject-label sub-001 \
+  --session-label ses-01
+bidsflow heudiconv run \
+  --config examples/project.toml \
+  --subject-label sub-001 \
+  --session-label ses-01 \
   --dry-run
-bidsflow curate --config examples/project.toml --participant sub-001
 ```

--- a/docs/design/cli-conventions.md
+++ b/docs/design/cli-conventions.md
@@ -1,0 +1,165 @@
+# CLI conventions
+
+## 1. Purpose
+
+BIDSFlow should expose a CLI that is easy to predict across stages while
+still respecting the semantics of each underlying tool.
+
+The CLI should therefore separate:
+
+- user-facing command naming
+- stage capability naming
+- scope selection
+- scheduler and backend selection
+- tool-specific execution details
+
+## 2. User-facing command names
+
+Prefer concrete tool names over abstract stage-category names.
+
+Examples:
+
+- `heudiconv`
+- `validate`
+- `fmriprep`
+- `mriqc`
+- `xcpd`
+- `qsiprep`
+- `qsirecon`
+
+Terms such as "curation stage" remain useful in design docs, but they
+should not be the primary user-facing command when a stage is tightly
+bound to a specific tool.
+
+### 2.1 Transitional note
+
+The current scaffold still exposes `curate`. The intended CLI direction
+is to rename this surface to `heudiconv` while preserving the idea that
+it belongs to the broader curation stage category.
+
+## 3. Capability-oriented subcommands
+
+Not every stage needs the same subcommands. BIDSFlow should expose
+subcommands based on stage capability rather than forcing a fully
+symmetric tree.
+
+Recommended common capabilities:
+
+- `check` - verify readiness without launching the underlying tool
+- `run` - begin execution using the configured local or scheduled mode
+
+Recommended stage-specific capabilities:
+
+- `bootstrap` - create starting materials needed before a real run
+
+Future capabilities may include:
+
+- `inspect`
+- `status`
+- `cancel`
+
+## 4. Action semantics
+
+### 4.1 `run`
+
+`run` means "start the stage". It should not split into separate
+user-facing `run` and `submit` commands at the current project stage.
+
+If the selected scheduler is:
+
+- `local`, BIDSFlow executes the stage directly
+- `sge`, BIDSFlow submits the stage and returns the job id
+
+This keeps the user mental model simple: `run` starts work, regardless
+of where that work is executed.
+
+### 4.2 `--dry-run`
+
+`--dry-run` should remain the primary execution preview surface for now.
+It is sufficient for single-stage preview because it can show:
+
+- resolved scope units
+- resolved command argv
+- resolved working, log, and output paths
+- scheduler submission details when applicable
+
+A dedicated `plan` command should be reserved for future cases where
+BIDSFlow needs to expand and report a larger structured execution plan.
+
+### 4.3 `check`
+
+`check` should answer whether a stage is ready to run without launching
+the stage executor.
+
+It should cover at least:
+
+- structural readiness
+- semantic readiness
+- backend readiness
+- dependency or handoff readiness
+
+Suggested outcomes:
+
+- `ready`
+- `warning`
+- `blocked`
+
+## 5. Scope parameter naming
+
+Use BIDS-oriented scope names at the BIDSFlow layer.
+
+Preferred flags:
+
+- `--subject-label`
+- `--session-label`
+- `--all`
+
+Compatibility aliases may include:
+
+- `--participant-label`
+
+Avoid exposing `--participant` as the long-term primary name.
+
+CLI inputs may accept either prefixed or unprefixed forms:
+
+- `sub-01` or `01`
+- `ses-01` or `01`
+
+BIDSFlow should normalize these values internally before mapping them to
+tool-specific flags.
+
+## 6. Separation of responsibilities
+
+Keep these concerns distinct:
+
+1. scope discovery
+2. readiness checking
+3. tool-specific argv construction
+4. backend wrapping
+5. scheduler submission
+
+In particular, scope discovery should happen before tool-specific
+command construction. A command builder should receive normalized scope
+units rather than be responsible for filesystem discovery on its own.
+
+## 7. Configuration interaction
+
+CLI conventions should not force a project config file to exist for
+every command. Some commands should be able to run without a config and
+help the user bootstrap one.
+
+Likely config-optional commands:
+
+- `doctor`
+- `init`
+- `heudiconv bootstrap`
+
+Likely config-backed commands:
+
+- `run`
+- `check`
+
+The exact command set may evolve, but the default bias should be:
+
+- use config for project defaults and reproducibility
+- do not require config where it creates unnecessary friction

--- a/docs/design/cli-conventions.md
+++ b/docs/design/cli-conventions.md
@@ -33,9 +33,9 @@ bound to a specific tool.
 
 ### 2.1 Transitional note
 
-The current scaffold still exposes `curate`. The intended CLI direction
-is to rename this surface to `heudiconv` while preserving the idea that
-it belongs to the broader curation stage category.
+The primary user-facing command is `heudiconv`. Earlier design drafts
+used `curate` as a stage-category-oriented name, but the CLI should now
+consistently use the concrete tool name.
 
 ## 3. Capability-oriented subcommands
 

--- a/docs/design/config-strategy.md
+++ b/docs/design/config-strategy.md
@@ -1,0 +1,185 @@
+# Configuration strategy
+
+## 1. Purpose
+
+BIDSFlow needs project-level configuration, but it should not force a
+config file to be the starting point for every workflow.
+
+This document defines the intended role of project configuration,
+command-line overrides, and external tool-specific artifacts.
+
+## 2. Design goals
+
+The configuration model should remain:
+
+- reproducible
+- inspectable
+- small enough to read comfortably
+- expressive enough for real projects
+- compatible with stage-specific tool semantics
+
+## 3. Root project config
+
+BIDSFlow should have one canonical root project config file.
+
+Recommended long-term filename:
+
+- `bidsflow.toml`
+
+The current scaffold uses `examples/project.toml` as an example shape.
+The final filename may change, but the role should remain stable.
+
+The root config should hold:
+
+- project paths and dataset roots
+- execution defaults
+- scheduler defaults
+- stage-level high-frequency defaults
+
+It should act as the canonical source for project defaults and
+provenance snapshots.
+
+## 4. Config is important, not universal
+
+Project configuration should not be treated as a universal precondition
+for every command.
+
+Commands can be grouped into two broad classes.
+
+### 4.1 Config-optional commands
+
+These commands can help users discover state or bootstrap a project
+before a canonical config exists.
+
+Examples:
+
+- `doctor`
+- `init`
+- `heudiconv bootstrap`
+- future `inspect`-style commands
+
+### 4.2 Config-backed commands
+
+These commands generally benefit from project defaults, reproducibility,
+and stable output layout.
+
+Examples:
+
+- `run`
+- `check`
+- scheduler-backed execution
+
+## 5. One root config, many referenced artifacts
+
+The preferred model is:
+
+- one root BIDSFlow config
+- multiple referenced stage or tool artifacts
+
+This is better than either extreme:
+
+- one giant TOML that mirrors every tool flag
+- one separate TOML per stage with no clear project entry point
+
+## 6. What belongs in the root config
+
+Put these kinds of settings in the root config:
+
+- project roots
+- execution backend defaults
+- scheduler defaults
+- stage defaults that are high-frequency and stable
+- paths to external stage-specific files
+
+Examples:
+
+- `heudiconv.heuristic`
+- `heudiconv.dicom_dir_template`
+- `fmriprep.output_spaces`
+- `fmriprep.mem_mb`
+
+## 7. What should stay external
+
+Do not force every tool-native artifact into TOML.
+
+Keep naturally independent artifacts in their own formats and reference
+them by path from the root config.
+
+Examples:
+
+- HeuDiConv `heuristic.py`
+- `dcm2niix` configuration files
+- future BIDS filter files
+- future plugin or site-specific scheduler snippets
+
+This keeps the root config readable and preserves the native structure
+of tool-specific content.
+
+## 8. Parameter classes
+
+Settings should be thought of in four classes.
+
+### 8.1 BIDSFlow-wide CLI parameters
+
+Examples:
+
+- `--config`
+- `--backend`
+- `--scheduler`
+- `--dry-run`
+- `--subject-label`
+- `--session-label`
+- `--all`
+
+### 8.2 Subcommand-fixed semantics
+
+These should be defined by the action being performed rather than by a
+user-set config key.
+
+Examples:
+
+- `heudiconv bootstrap` generates heuristic starting materials
+- `heudiconv run` performs a real conversion
+- `check` does not launch the stage executor
+
+### 8.3 Stage-level defaults
+
+These are the main candidates for root config fields.
+
+Examples:
+
+- HeuDiConv heuristic path
+- DICOM discovery template
+- output directory
+- converter default
+
+### 8.4 Advanced escape hatches
+
+Some rare tool-specific flags may not deserve first-class schema fields
+immediately. These should be added conservatively and only when real use
+cases justify them.
+
+Typed schema fields should remain the default preference.
+
+## 9. Resolution order
+
+When multiple sources define a value, use this order:
+
+1. subcommand-fixed behavior
+2. explicit CLI argument
+3. root project config
+4. underlying tool default
+
+This order should be documented and kept consistent across stages.
+
+## 10. Schema guidance
+
+When adding config fields:
+
+- prefer typed, explicit fields
+- keep stage blocks small
+- avoid mirroring an entire upstream CLI without evidence
+- favor file references over embedding complex native formats
+
+The goal is semantic completeness for project orchestration, not
+one-to-one replication of every upstream tool flag.

--- a/docs/design/handoff-contract.md
+++ b/docs/design/handoff-contract.md
@@ -77,13 +77,13 @@ Examples:
 
 ## 4. Handoff classes in the initial BIDSFlow scope
 
-### 4.1 `curate -> validate`
+### 4.1 `heudiconv -> validate`
 
-The curation stage should hand off:
+The HeuDiConv stage should hand off:
 
 - a raw BIDS root
 - top-level BIDS metadata
-- participant/session coverage summary
+- subject/session coverage summary
 - any known curation warnings
 
 ### 4.2 `validate -> fmriprep`
@@ -91,14 +91,14 @@ The curation stage should hand off:
 Validation should hand off confirmation that:
 
 - the raw dataset is structurally readable
-- necessary functional/anatomical modalities exist for the selected participant(s)
+- necessary functional/anatomical modalities exist for the selected subject(s)
 - no blocking dataset-level errors remain
 
 ### 4.3 `validate -> mriqc`
 
 Validation should hand off confirmation that:
 
-- the selected participant(s) exist in raw BIDS
+- the selected subject(s) exist in raw BIDS
 - raw image files needed for MRIQC are available
 - the intended scope selection is coherent
 
@@ -108,7 +108,7 @@ This is a critical derivative handoff. The contract should verify at least:
 
 - fMRIPrep derivative root exists
 - derivative `dataset_description.json` exists
-- participant coverage matches the intended scope
+- subject coverage matches the intended scope
 - required spaces or file formats for the requested XCP-D mode are available
 - provenance records identify the upstream fMRIPrep run
 
@@ -116,7 +116,7 @@ This is a critical derivative handoff. The contract should verify at least:
 
 Validation should hand off confirmation that:
 
-- diffusion data are present for selected participants
+- diffusion data are present for selected subjects
 - accompanying structural inputs exist if required by the chosen configuration
 - no blocking raw-data structure issues remain
 
@@ -135,7 +135,7 @@ Passing only a directory path is inadequate because downstream stages
 need more than location. They need assurances about:
 
 - semantic compatibility
-- participant/session coverage
+- subject/session coverage
 - modality completeness
 - provenance lineage
 - configuration compatibility

--- a/docs/design/heudiconv-workflow.md
+++ b/docs/design/heudiconv-workflow.md
@@ -1,0 +1,120 @@
+# HeuDiConv workflow
+
+## 1. Purpose
+
+HeuDiConv is not only a conversion executor. In practice it also serves
+as the entry point for discovering source data structure and building an
+initial heuristic.
+
+BIDSFlow should therefore model HeuDiConv as a small workflow rather
+than as a single opaque command.
+
+## 2. User-facing command name
+
+The preferred user-facing command is:
+
+- `heudiconv`
+
+This is clearer than exposing the stage only as `curate`, even though
+HeuDiConv still belongs to the broader curation stage category.
+
+## 3. Subcommands
+
+Recommended initial subcommands:
+
+- `bootstrap`
+- `check`
+- `run`
+
+### 3.1 `bootstrap`
+
+`bootstrap` helps the user create the initial materials needed for a
+real conversion workflow.
+
+It should be designed to produce or preserve:
+
+- a starter `heuristic.py`
+- the discovery outputs that help a user edit that heuristic
+
+This step should bias toward explicit sample selection rather than
+silently choosing an arbitrary subject or session.
+
+### 3.2 `check`
+
+`check` verifies that the intended HeuDiConv run is structurally ready
+without running the real conversion.
+
+Expected checks include:
+
+- source discovery succeeds
+- selected subject or session exists
+- heuristic file exists when required
+- output location is writable
+- backend or executable is available
+
+### 3.3 `run`
+
+`run` performs the real conversion workflow.
+
+At the BIDSFlow layer, `run` should remain scheduler-agnostic:
+
+- local execution runs directly
+- scheduled execution submits the work and reports the job id
+
+## 4. Scope discovery
+
+HeuDiConv needs to discover the execution units it should process. This
+should be modeled as a BIDSFlow concern rather than buried inside a
+single command builder.
+
+Recommended CLI behavior:
+
+- `--subject-label` plus `--session-label` selects one unit
+- `--subject-label` alone expands all sessions for that subject
+- `--all` expands all discovered units
+
+This pattern should inform future stage implementations as well, even if
+the discovery source changes from DICOM inputs to BIDS or derivative
+datasets.
+
+## 5. Scope normalization
+
+BIDSFlow should normalize subject and session labels before passing them
+to HeuDiConv.
+
+Examples:
+
+- `sub-001` and `001` should normalize to the same subject label
+- `ses-01` and `01` should normalize to the same session label
+
+The command builder can then map the normalized values to HeuDiConv's
+native flags without duplicating label-cleaning logic.
+
+## 6. Config interaction
+
+HeuDiConv should work with project configuration, but bootstrap-oriented
+flows should not require a pre-existing root config file.
+
+When config is present, it should provide defaults for:
+
+- heuristic path
+- DICOM discovery strategy
+- output root
+- converter selection
+
+When config is absent, bootstrap flows may still run using explicit CLI
+inputs and can help create the project defaults that will later be
+stored in the root config.
+
+## 7. Separation of builder layers
+
+Keep the HeuDiConv implementation split into layers:
+
+1. discover scope units
+2. resolve stage defaults and CLI overrides
+3. build HeuDiConv argv
+4. wrap for native or container execution
+5. submit through the selected scheduler if needed
+
+This keeps HeuDiConv-specific logic compatible with the broader BIDSFlow
+orchestration model.

--- a/docs/design/stage-model.md
+++ b/docs/design/stage-model.md
@@ -36,7 +36,7 @@ following minimum fields:
 
 The initial stage inventory is:
 
-1. `curate` — HeuDiConv-backed curation into raw BIDS
+1. `heudiconv` — HeuDiConv-backed curation into raw BIDS
 2. `validate` — dataset or derivative validation
 3. `fmriprep` — functional/anatomical MRI preprocessing
 4. `mriqc` — MRI quality control
@@ -55,7 +55,7 @@ Transforms sourcedata into a BIDS-aware raw dataset.
 
 Representative stage:
 
-- `curate`
+- `heudiconv`
 
 ### 4.2 Validation stage
 
@@ -92,11 +92,11 @@ failure isolation, and rerun behavior.
 Recommended scopes:
 
 - `dataset`: the whole dataset
-- `participant`: one participant at a time
-- `participant/session`: one participant-session unit
+- `subject`: one subject at a time
+- `subject/session`: one subject-session unit
 
 The default operational unit for most heavy stages should be
-`participant` or `participant/session`, because this aligns well with
+`subject` or `subject/session`, because this aligns well with
 containerized neuroimaging workflows and supports partial recovery.
 
 ## 6. State model
@@ -144,7 +144,7 @@ should also verify expected products.
 
 Examples:
 
-- `curate`: raw BIDS root exists and contains required top-level files
+- `heudiconv`: raw BIDS root exists and contains required top-level files
 - `fmriprep`: derivative dataset exists with valid `dataset_description.json`
 - `xcpd`: derivative outputs exist for requested participants and
   requested mode
@@ -166,7 +166,7 @@ Determinants may include:
 
 The initial dependency graph should be simple and explicit:
 
-- `curate -> validate`
+- `heudiconv -> validate`
 - `validate -> fmriprep`
 - `validate -> mriqc`
 - `validate -> qsiprep`
@@ -182,7 +182,7 @@ The CLI should center on stage commands rather than a hidden master
 pipeline. This implies:
 
 - one command per stage
-- explicit participant/session selection
+- explicit subject/session selection
 - explicit config input
 - explicit status inspection
 - future support for planned multi-stage execution that still surfaces

--- a/docs/setup/sge-site-config.md
+++ b/docs/setup/sge-site-config.md
@@ -94,7 +94,7 @@ bidsflow config validate --config examples/project.toml
 ```bash
 bidsflow fmriprep \
   --config examples/project.toml \
-  --participant sub-001 \
+  --subject-label sub-001 \
   --dry-run
 ```
 
@@ -103,7 +103,7 @@ bidsflow fmriprep \
 ```bash
 bidsflow fmriprep \
   --config examples/project.toml \
-  --participant sub-001
+  --subject-label sub-001
 ```
 
 At the current development stage, this submits a lightweight BIDSFlow

--- a/examples/project.toml
+++ b/examples/project.toml
@@ -1,6 +1,7 @@
 [project]
 name = "Example BIDSFlow project"
 root = ".."
+sourcedata_root = "sourcedata/dicom"
 bids_root = "sourcedata/raw"
 derivatives_root = "derivatives"
 
@@ -34,9 +35,14 @@ memory = "mem_free"
 
 [heudiconv]
 enabled = true
+executable = "heudiconv"
+dicom_dir_template = "{bids_subject}/{bids_session}/*/*.dcm"
 heuristic = "code/heuristics/heuristic.py"
 outdir = "sourcedata/raw"
 converter = "dcm2niix"
+minmeta = false
+overwrite = false
+with_prov = false
 
 [fmriprep]
 enabled = true

--- a/src/bidsflow/cli.py
+++ b/src/bidsflow/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import os
 import shlex
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Literal
 
@@ -15,15 +17,30 @@ from bidsflow.config.models import Config
 from bidsflow.core.stages import STAGES, StageId
 from bidsflow.scheduler.models import SubmittedJob
 from bidsflow.scheduler.sge import SGECliScheduler
+from bidsflow.stages.heudiconv import (
+    CommandSpec,
+    ReadinessResult,
+    ScopeUnit,
+    build_bootstrap_command,
+    build_run_command,
+    check_readiness,
+    find_bootstrap_dicominfo,
+    find_bootstrap_heuristic,
+    format_session_label,
+    format_subject_label,
+)
 
 SchedulerChoice = Literal["local", "sge"]
+BackendChoice = Literal["docker", "apptainer", "native"]
 
 app = typer.Typer(
     help="BIDSFlow: a staged Python CLI orchestrator for BIDS Apps.",
     no_args_is_help=True,
 )
 config_app = typer.Typer(help="Configuration helpers.")
+heudiconv_app = typer.Typer(help="HeuDiConv stage helpers.")
 app.add_typer(config_app, name="config")
+app.add_typer(heudiconv_app, name="heudiconv")
 console = Console()
 
 
@@ -49,6 +66,9 @@ def doctor(
     table.add_column("Result")
 
     table.add_row("python", shutil.which("python") or "not found")
+    table.add_row("heudiconv", shutil.which("heudiconv") or "not found")
+    table.add_row("apptainer", shutil.which("apptainer") or "not found")
+    table.add_row("docker", shutil.which("docker") or "not found")
     table.add_row("qsub", shutil.which("qsub") or "not found")
     table.add_row("qstat", shutil.which("qstat") or "not found")
 
@@ -57,9 +77,10 @@ def doctor(
         table.add_row("config", str(config.resolve()))
         table.add_row("backend", loaded.execution.backend)
         table.add_row("scheduler", loaded.execution.scheduler)
+        table.add_row("project root", str(loaded.project.root))
+        table.add_row("sourcedata root", str(loaded.project.sourcedata_root))
         if loaded.execution.scheduler == "sge":
             table.add_row("sge queue", loaded.scheduler.sge.queue or "-")
-            table.add_row("project root", str(loaded.project.root))
 
     console.print(table)
 
@@ -80,6 +101,7 @@ def config_validate(
     table.add_column("Value")
     table.add_row("config", str(config.resolve()))
     table.add_row("project root", str(loaded.project.root))
+    table.add_row("sourcedata root", str(loaded.project.sourcedata_root))
     table.add_row("backend", loaded.execution.backend)
     table.add_row("scheduler", loaded.execution.scheduler)
     if loaded.execution.scheduler == "sge":
@@ -106,10 +128,23 @@ def _resolve_scheduler(config: Config, scheduler: SchedulerChoice | None) -> Sch
     return config.execution.scheduler if scheduler is None else scheduler
 
 
-def _ensure_stage_scope(stage: StageId, participant: str | None) -> None:
+def _apply_execution_overrides(
+    config: Config,
+    *,
+    backend: BackendChoice | None = None,
+    scheduler: SchedulerChoice | None = None,
+) -> Config:
+    if backend is not None:
+        config.execution.backend = backend
+    if scheduler is not None:
+        config.execution.scheduler = scheduler
+    return config
+
+
+def _ensure_stage_scope(stage: StageId, subject_label: str | None) -> None:
     stage_spec = STAGES[stage]
-    if stage_spec.scope == "dataset" and participant is not None:
-        console.print(f"Stage '{stage.value}' has dataset scope and does not accept --participant.")
+    if stage_spec.scope == "dataset" and subject_label is not None:
+        console.print(f"Stage '{stage.value}' has dataset scope and does not accept --subject-label.")
         raise typer.Exit(code=2)
 
 
@@ -117,7 +152,7 @@ def _build_local_stage_command(
     *,
     stage: StageId,
     config_path: Path,
-    participant: str | None,
+    subject_label: str | None,
 ) -> tuple[str, ...]:
     command = (
         "bidsflow",
@@ -127,39 +162,47 @@ def _build_local_stage_command(
         "--scheduler",
         "local",
     )
-    if participant is None:
+    if subject_label is None:
         return command
-    return (*command, "--participant", participant)
+    return (*command, "--subject-label", subject_label)
+
+
+def _format_scope(subject_label: str | None, session_label: str | None = None) -> str:
+    if subject_label is None:
+        return "-"
+    if session_label is None:
+        return format_subject_label(subject_label)
+    return f"{format_subject_label(subject_label)} / {format_session_label(session_label)}"
 
 
 def _print_local_stage_preview(
     *,
     stage: StageId,
     config_path: Path,
-    participant: str | None,
+    subject_label: str | None,
     loaded: Config,
 ) -> None:
     command = _build_local_stage_command(
         stage=stage,
         config_path=config_path,
-        participant=participant,
+        subject_label=subject_label,
     )
     table = Table(title="Local stage run preview")
     table.add_column("Field")
     table.add_column("Value")
     table.add_row("stage", stage.value)
-    table.add_row("participant", participant or "-")
+    table.add_row("scope", _format_scope(subject_label))
     table.add_row("scheduler", "local")
     table.add_row("cwd", str(loaded.project.root))
     table.add_row("command", shlex.join(command))
     console.print(table)
 
 
-def _run_local_stage(stage: StageId, config_path: Path, participant: str | None) -> None:
+def _run_local_stage(stage: StageId, config_path: Path, subject_label: str | None) -> None:
     stage_spec = STAGES[stage]
     console.print(
         f"{stage_spec.label} stage requested with config={config_path.resolve()} "
-        f"participant={participant or '-'}"
+        f"scope={_format_scope(subject_label)}"
     )
 
 
@@ -170,7 +213,8 @@ def _load_sge_scheduler(config: Config) -> SGECliScheduler:
 def _print_sge_stage_preview(
     *,
     stage: StageId,
-    participant: str | None,
+    subject_label: str | None,
+    session_label: str | None,
     plan_script: str,
     plan_command: tuple[str, ...],
     launch_command: tuple[str, ...],
@@ -182,7 +226,7 @@ def _print_sge_stage_preview(
     table.add_column("Field")
     table.add_column("Value")
     table.add_row("stage", stage.value)
-    table.add_row("participant", participant or "-")
+    table.add_row("scope", _format_scope(subject_label, session_label))
     table.add_row("scheduler", "sge")
     table.add_row("script path", str(script_path))
     table.add_row("stdout", str(stdout_path))
@@ -197,13 +241,13 @@ def _run_stage(
     *,
     stage: StageId,
     config: Path,
-    participant: str | None,
+    subject_label: str | None,
     scheduler: SchedulerChoice | None,
     dry_run: bool,
     hold_jid: str | None,
 ) -> None:
     loaded = load_config(config)
-    _ensure_stage_scope(stage, participant)
+    _ensure_stage_scope(stage, subject_label)
     effective_scheduler = _resolve_scheduler(loaded, scheduler)
 
     if effective_scheduler == "local":
@@ -214,11 +258,11 @@ def _run_stage(
             _print_local_stage_preview(
                 stage=stage,
                 config_path=config,
-                participant=participant,
+                subject_label=subject_label,
                 loaded=loaded,
             )
             return
-        _run_local_stage(stage=stage, config_path=config, participant=participant)
+        _run_local_stage(stage=stage, config_path=config, subject_label=subject_label)
         return
 
     scheduler_runner = _load_sge_scheduler(loaded)
@@ -226,12 +270,14 @@ def _run_stage(
         config_path=config,
         config=loaded,
         stage=stage,
-        participant=participant,
+        subject_label=subject_label,
+        session_label=None,
         hold_jid=hold_jid,
     )
     _print_sge_stage_preview(
         stage=stage,
-        participant=participant,
+        subject_label=subject_label,
+        session_label=None,
         plan_script=plan.script_text,
         plan_command=plan.qsub_command,
         launch_command=plan.launch.command,
@@ -246,10 +292,372 @@ def _run_stage(
     console.print(f"Submitted SGE job {submitted.job_id}")
 
 
-@app.command()
-def curate(
+def _load_bootstrap_config(
+    *,
+    config_path: Path | None,
+    backend: BackendChoice | None,
+    source_root: Path | None,
+    heuristic: Path | None,
+    outdir: Path | None,
+    dicom_dir_template: str | None,
+) -> Config:
+    if config_path is None:
+        loaded = Config()
+        cwd = Path.cwd().resolve()
+        loaded.project.root = cwd
+        loaded.project.sourcedata_root = (source_root or cwd).resolve()
+        loaded.project.bids_root = (outdir or cwd / "sourcedata" / "raw").resolve()
+        loaded.project.derivatives_root = (cwd / "derivatives").resolve()
+        loaded.execution.work_root = (cwd / "work").resolve()
+        loaded.execution.logs_root = (cwd / "logs").resolve()
+        loaded.execution.state_root = (cwd / "state").resolve()
+        loaded.execution.backend = backend or "native"
+        loaded.execution.scheduler = "local"
+        loaded.heudiconv.outdir = (outdir or loaded.project.bids_root).resolve()
+    else:
+        loaded = load_config(config_path)
+
+    if backend is not None:
+        loaded.execution.backend = backend
+    if source_root is not None:
+        loaded.project.sourcedata_root = source_root.resolve()
+    if heuristic is not None:
+        loaded.heudiconv.heuristic = heuristic.resolve()
+    if outdir is not None:
+        loaded.heudiconv.outdir = outdir.resolve()
+    if dicom_dir_template is not None:
+        loaded.heudiconv.dicom_dir_template = dicom_dir_template
+    return loaded
+
+
+def _print_heudiconv_check_result(readiness: ReadinessResult, *, loaded: Config) -> None:
+    table = Table(title="HeuDiConv check")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("status", readiness.status)
+    table.add_row("backend", loaded.execution.backend)
+    table.add_row("units", ", ".join(unit.display_name for unit in readiness.units) or "-")
+    for index, message in enumerate(readiness.messages, start=1):
+        table.add_row(f"message {index}", message)
+    console.print(table)
+
+
+def _print_heudiconv_local_preview(
+    *,
+    mode: Literal["bootstrap", "run"],
+    loaded: Config,
+    unit: ScopeUnit,
+    command_spec: CommandSpec,
+) -> None:
+    table = Table(title=f"HeuDiConv {mode} preview")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("stage", StageId.HEUDICONV.value)
+    table.add_row("mode", mode)
+    table.add_row("scope", unit.display_name)
+    table.add_row("backend", loaded.execution.backend)
+    table.add_row("cwd", str(command_spec.cwd))
+    table.add_row("command", shlex.join(command_spec.command))
+    table.add_row("outdir", str(loaded.heudiconv.outdir))
+    console.print(table)
+
+
+def _execute_command(command_spec: CommandSpec, *, prepare_paths: tuple[Path, ...] = ()) -> None:
+    for path in prepare_paths:
+        path.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.update(command_spec.env)
+    subprocess.run(
+        command_spec.command,
+        cwd=command_spec.cwd,
+        env=env,
+        check=True,
+    )
+
+
+def _copy_bootstrap_heuristic(
+    *,
+    generated_heuristic: Path | None,
+    target_heuristic: Path | None,
+    overwrite: bool,
+) -> Path | None:
+    if generated_heuristic is None or target_heuristic is None:
+        return None
+    target_heuristic.parent.mkdir(parents=True, exist_ok=True)
+    if target_heuristic.exists() and not overwrite:
+        return target_heuristic
+    shutil.copy2(generated_heuristic, target_heuristic)
+    return target_heuristic
+
+
+def _heudiconv_run_impl(
+    *,
+    config: Path,
+    subject_label: str | None,
+    session_label: str | None,
+    all_units: bool,
+    files: tuple[Path, ...],
+    backend: BackendChoice | None,
+    scheduler: SchedulerChoice | None,
+    dry_run: bool,
+    hold_jid: str | None,
+) -> None:
+    loaded = load_config(config)
+    _apply_execution_overrides(loaded, backend=backend, scheduler=scheduler)
+    effective_scheduler = _resolve_scheduler(loaded, scheduler)
+
+    readiness = check_readiness(
+        loaded,
+        mode="run",
+        subject_label=subject_label,
+        session_label=session_label,
+        all_units=all_units,
+        files=files,
+    )
+    _print_heudiconv_check_result(readiness, loaded=loaded)
+    if readiness.status == "blocked":
+        raise typer.Exit(code=1)
+
+    if files and effective_scheduler == "sge":
+        console.print("Explicit --files inputs are not yet supported with --scheduler sge.")
+        raise typer.Exit(code=2)
+
+    if effective_scheduler == "local":
+        if hold_jid is not None:
+            console.print("--hold-jid is only supported when --scheduler sge is active.")
+            raise typer.Exit(code=2)
+        for unit in readiness.units:
+            command_spec = build_run_command(
+                loaded,
+                subject_label=unit.subject_label,
+                session_label=unit.session_label,
+                files=files,
+            )
+            _print_heudiconv_local_preview(
+                mode="run",
+                loaded=loaded,
+                unit=unit,
+                command_spec=command_spec,
+            )
+            if dry_run:
+                continue
+            try:
+                _execute_command(command_spec, prepare_paths=(loaded.heudiconv.outdir.parent,))
+            except subprocess.CalledProcessError as error:
+                console.print(f"HeuDiConv run failed for {unit.display_name} with exit code {error.returncode}.")
+                raise typer.Exit(code=1) from error
+        return
+
+    scheduler_runner = _load_sge_scheduler(loaded)
+    for unit in readiness.units:
+        plan = scheduler_runner.plan_stage_submission(
+            config_path=config,
+            config=loaded,
+            stage=StageId.HEUDICONV,
+            subject_label=unit.subject_label,
+            session_label=unit.session_label,
+            hold_jid=hold_jid,
+        )
+        _print_sge_stage_preview(
+            stage=StageId.HEUDICONV,
+            subject_label=unit.subject_label,
+            session_label=unit.session_label,
+            plan_script=plan.script_text,
+            plan_command=plan.qsub_command,
+            launch_command=plan.launch.command,
+            script_path=plan.script_path,
+            stdout_path=plan.launch.stdout_path,
+            stderr_path=plan.launch.stderr_path,
+        )
+        if dry_run:
+            continue
+        submitted = scheduler_runner.submit(plan)
+        console.print(f"Submitted SGE job {submitted.job_id} for {unit.display_name}")
+
+
+@heudiconv_app.command("bootstrap")
+def heudiconv_bootstrap(
+    config: Path | None = typer.Option(
+        None,
+        exists=True,
+        dir_okay=False,
+        help="Optional path to a TOML config.",
+    ),
+    subject_label: str = typer.Option(
+        ...,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
+    session_label: str | None = typer.Option(
+        None,
+        "--session-label",
+        help="Optional session label, e.g. ses-01 or 01.",
+    ),
+    source_root: Path | None = typer.Option(
+        None,
+        help="Override the sourcedata root used for DICOM discovery.",
+    ),
+    dicom_dir_template: str | None = typer.Option(
+        None,
+        help="Override the HeuDiConv DICOM template. Required when no config provides one.",
+    ),
+    files: list[Path] | None = typer.Option(
+        None,
+        "--files",
+        help="Explicit input files or directories. Repeat --files to add more inputs.",
+    ),
+    heuristic: Path | None = typer.Option(
+        None,
+        help="Destination path for the copied bootstrap heuristic.py file.",
+    ),
+    outdir: Path | None = typer.Option(
+        None,
+        help="Override the HeuDiConv output root.",
+    ),
+    backend: BackendChoice | None = typer.Option(
+        None,
+        help="Override the execution backend for bootstrap.",
+    ),
+    dry_run: bool = typer.Option(False, help="Preview the bootstrap command without running it."),
+) -> None:
+    """Generate heuristic bootstrap materials from representative DICOM inputs."""
+    loaded = _load_bootstrap_config(
+        config_path=config,
+        backend=backend,
+        source_root=source_root,
+        heuristic=heuristic,
+        outdir=outdir,
+        dicom_dir_template=dicom_dir_template,
+    )
+    file_inputs = tuple(path.resolve() for path in (files or []))
+
+    readiness = check_readiness(
+        loaded,
+        mode="bootstrap",
+        subject_label=subject_label,
+        session_label=session_label,
+        all_units=False,
+        files=file_inputs,
+    )
+    _print_heudiconv_check_result(readiness, loaded=loaded)
+    if readiness.status == "blocked":
+        raise typer.Exit(code=1)
+
+    unit = readiness.units[0]
+    command_spec = build_bootstrap_command(
+        loaded,
+        subject_label=unit.subject_label,
+        session_label=unit.session_label,
+        files=file_inputs,
+    )
+    _print_heudiconv_local_preview(
+        mode="bootstrap",
+        loaded=loaded,
+        unit=unit,
+        command_spec=command_spec,
+    )
+    if dry_run:
+        return
+
+    try:
+        _execute_command(command_spec, prepare_paths=(loaded.heudiconv.outdir.parent,))
+    except subprocess.CalledProcessError as error:
+        console.print(f"HeuDiConv bootstrap failed with exit code {error.returncode}.")
+        raise typer.Exit(code=1) from error
+
+    generated_heuristic = find_bootstrap_heuristic(
+        loaded.heudiconv.outdir,
+        subject_label=unit.subject_label,
+        session_label=unit.session_label,
+    )
+    copied_heuristic = _copy_bootstrap_heuristic(
+        generated_heuristic=generated_heuristic,
+        target_heuristic=loaded.heudiconv.heuristic,
+        overwrite=loaded.heudiconv.overwrite,
+    )
+    dicominfo = find_bootstrap_dicominfo(
+        loaded.heudiconv.outdir,
+        subject_label=unit.subject_label,
+        session_label=unit.session_label,
+    )
+
+    table = Table(title="HeuDiConv bootstrap results")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("scope", unit.display_name)
+    table.add_row("generated heuristic", str(generated_heuristic) if generated_heuristic else "not found")
+    table.add_row("copied heuristic", str(copied_heuristic) if copied_heuristic else "-")
+    table.add_row("dicominfo.tsv", str(dicominfo) if dicominfo else "not found")
+    console.print(table)
+
+
+@heudiconv_app.command("check")
+def heudiconv_check(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
+    session_label: str | None = typer.Option(
+        None,
+        "--session-label",
+        help="Optional session label, e.g. ses-01 or 01.",
+    ),
+    all_units: bool = typer.Option(False, "--all", help="Check all discoverable HeuDiConv scope units."),
+    files: list[Path] | None = typer.Option(
+        None,
+        "--files",
+        help="Explicit input files or directories. Repeat --files to add more inputs.",
+    ),
+    backend: BackendChoice | None = typer.Option(
+        None,
+        help="Override the backend declared in the config for this check.",
+    ),
+) -> None:
+    """Check whether the HeuDiConv stage is ready to run."""
+    loaded = load_config(config)
+    _apply_execution_overrides(loaded, backend=backend)
+    readiness = check_readiness(
+        loaded,
+        mode="run",
+        subject_label=subject_label,
+        session_label=session_label,
+        all_units=all_units,
+        files=tuple(path.resolve() for path in (files or [])),
+    )
+    _print_heudiconv_check_result(readiness, loaded=loaded)
+    if readiness.status == "blocked":
+        raise typer.Exit(code=1)
+
+
+@heudiconv_app.command("run")
+def heudiconv_run(
+    config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
+    session_label: str | None = typer.Option(
+        None,
+        "--session-label",
+        help="Optional session label, e.g. ses-01 or 01.",
+    ),
+    all_units: bool = typer.Option(False, "--all", help="Run all discoverable HeuDiConv scope units."),
+    files: list[Path] | None = typer.Option(
+        None,
+        "--files",
+        help="Explicit input files or directories. Repeat --files to add more inputs.",
+    ),
+    backend: BackendChoice | None = typer.Option(
+        None,
+        help="Override the backend declared in the config for this invocation.",
+    ),
     scheduler: SchedulerChoice | None = typer.Option(
         None,
         help="Override the scheduler declared in the config for this invocation.",
@@ -260,11 +668,14 @@ def curate(
         help="Optional upstream SGE job id dependency when using --scheduler sge.",
     ),
 ) -> None:
-    """Run or preview the HeuDiConv-backed curation stage."""
-    _run_stage(
-        stage=StageId.CURATE,
+    """Run or preview the HeuDiConv stage."""
+    _heudiconv_run_impl(
         config=config,
-        participant=participant,
+        subject_label=subject_label,
+        session_label=session_label,
+        all_units=all_units,
+        files=tuple(path.resolve() for path in (files or [])),
+        backend=backend,
         scheduler=scheduler,
         dry_run=dry_run,
         hold_jid=hold_jid,
@@ -274,7 +685,12 @@ def curate(
 @app.command(name="validate")
 def validate_stage(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
     scheduler: SchedulerChoice | None = typer.Option(
         None,
         help="Override the scheduler declared in the config for this invocation.",
@@ -289,7 +705,7 @@ def validate_stage(
     _run_stage(
         stage=StageId.VALIDATE,
         config=config,
-        participant=participant,
+        subject_label=subject_label,
         scheduler=scheduler,
         dry_run=dry_run,
         hold_jid=hold_jid,
@@ -299,7 +715,12 @@ def validate_stage(
 @app.command()
 def fmriprep(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
     scheduler: SchedulerChoice | None = typer.Option(
         None,
         help="Override the scheduler declared in the config for this invocation.",
@@ -314,7 +735,7 @@ def fmriprep(
     _run_stage(
         stage=StageId.FMRIPREP,
         config=config,
-        participant=participant,
+        subject_label=subject_label,
         scheduler=scheduler,
         dry_run=dry_run,
         hold_jid=hold_jid,
@@ -324,7 +745,12 @@ def fmriprep(
 @app.command()
 def mriqc(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
     scheduler: SchedulerChoice | None = typer.Option(
         None,
         help="Override the scheduler declared in the config for this invocation.",
@@ -339,7 +765,7 @@ def mriqc(
     _run_stage(
         stage=StageId.MRIQC,
         config=config,
-        participant=participant,
+        subject_label=subject_label,
         scheduler=scheduler,
         dry_run=dry_run,
         hold_jid=hold_jid,
@@ -349,7 +775,12 @@ def mriqc(
 @app.command(name="xcpd")
 def xcpd_cmd(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
     scheduler: SchedulerChoice | None = typer.Option(
         None,
         help="Override the scheduler declared in the config for this invocation.",
@@ -364,7 +795,7 @@ def xcpd_cmd(
     _run_stage(
         stage=StageId.XCPD,
         config=config,
-        participant=participant,
+        subject_label=subject_label,
         scheduler=scheduler,
         dry_run=dry_run,
         hold_jid=hold_jid,
@@ -374,7 +805,12 @@ def xcpd_cmd(
 @app.command()
 def qsiprep(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
     scheduler: SchedulerChoice | None = typer.Option(
         None,
         help="Override the scheduler declared in the config for this invocation.",
@@ -389,7 +825,7 @@ def qsiprep(
     _run_stage(
         stage=StageId.QSIPREP,
         config=config,
-        participant=participant,
+        subject_label=subject_label,
         scheduler=scheduler,
         dry_run=dry_run,
         hold_jid=hold_jid,
@@ -399,7 +835,12 @@ def qsiprep(
 @app.command()
 def qsirecon(
     config: Path = typer.Option(..., exists=True, dir_okay=False, help="Path to TOML config."),
-    participant: str | None = typer.Option(None, help="Participant label, e.g. sub-001."),
+    subject_label: str | None = typer.Option(
+        None,
+        "--subject-label",
+        "--participant-label",
+        help="Subject label, e.g. sub-001 or 001.",
+    ),
     scheduler: SchedulerChoice | None = typer.Option(
         None,
         help="Override the scheduler declared in the config for this invocation.",
@@ -414,7 +855,7 @@ def qsirecon(
     _run_stage(
         stage=StageId.QSIRECON,
         config=config,
-        participant=participant,
+        subject_label=subject_label,
         scheduler=scheduler,
         dry_run=dry_run,
         hold_jid=hold_jid,

--- a/src/bidsflow/config/load.py
+++ b/src/bidsflow/config/load.py
@@ -23,6 +23,7 @@ def load_config(path: Path) -> Config:
     config.project.root = _resolve_path(config.project.root, config_dir)
     project_root = config.project.root
 
+    config.project.sourcedata_root = _resolve_path(config.project.sourcedata_root, project_root)
     config.project.bids_root = _resolve_path(config.project.bids_root, project_root)
     config.project.derivatives_root = _resolve_path(config.project.derivatives_root, project_root)
 
@@ -30,8 +31,12 @@ def load_config(path: Path) -> Config:
     config.execution.logs_root = _resolve_path(config.execution.logs_root, project_root)
     config.execution.state_root = _resolve_path(config.execution.state_root, project_root)
 
+    if config.heudiconv.apptainer_image is not None:
+        config.heudiconv.apptainer_image = _resolve_path(config.heudiconv.apptainer_image, project_root)
     if config.heudiconv.heuristic is not None:
         config.heudiconv.heuristic = _resolve_path(config.heudiconv.heuristic, project_root)
     config.heudiconv.outdir = _resolve_path(config.heudiconv.outdir, project_root)
+    if config.heudiconv.dcmconfig is not None:
+        config.heudiconv.dcmconfig = _resolve_path(config.heudiconv.dcmconfig, project_root)
 
     return config

--- a/src/bidsflow/config/models.py
+++ b/src/bidsflow/config/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 class ProjectConfig(BaseModel):
     name: str = "BIDSFlow project"
     root: Path = Path(".")
+    sourcedata_root: Path = Path("sourcedata/dicom")
     bids_root: Path = Path("sourcedata/raw")
     derivatives_root: Path = Path("derivatives")
 
@@ -51,9 +52,17 @@ class SchedulerConfig(BaseModel):
 
 class HeudiconvConfig(BaseModel):
     enabled: bool = True
+    executable: str = "heudiconv"
+    docker_image: str | None = None
+    apptainer_image: Path | None = None
+    dicom_dir_template: str | None = None
     heuristic: Path | None = None
     outdir: Path = Path("sourcedata/raw")
     converter: Literal["dcm2niix", "none"] = "dcm2niix"
+    minmeta: bool = False
+    overwrite: bool = False
+    with_prov: bool = False
+    dcmconfig: Path | None = None
 
 
 class FMRIPrepConfig(BaseModel):

--- a/src/bidsflow/core/stages.py
+++ b/src/bidsflow/core/stages.py
@@ -5,7 +5,7 @@ from enum import Enum
 
 
 class StageId(str, Enum):
-    CURATE = "curate"
+    HEUDICONV = "heudiconv"
     VALIDATE = "validate"
     FMRIPREP = "fmriprep"
     MRIQC = "mriqc"
@@ -20,22 +20,22 @@ class StageSpec:
     label: str
     upstream: tuple[StageId, ...] = ()
     products: tuple[str, ...] = ()
-    scope: str = "participant"
+    scope: str = "subject"
     notes: str = ""
 
 
 STAGES: dict[StageId, StageSpec] = {
-    StageId.CURATE: StageSpec(
-        id=StageId.CURATE,
-        label="HeuDiConv curation",
+    StageId.HEUDICONV: StageSpec(
+        id=StageId.HEUDICONV,
+        label="HeuDiConv",
         products=("raw BIDS dataset",),
-        scope="participant/session",
+        scope="subject/session",
         notes="Transforms sourcedata into a BIDS-aware raw dataset.",
     ),
     StageId.VALIDATE: StageSpec(
         id=StageId.VALIDATE,
         label="Validation",
-        upstream=(StageId.CURATE,),
+        upstream=(StageId.HEUDICONV,),
         products=("validation report",),
         scope="dataset",
         notes="Validates raw or derivative inputs before downstream execution.",

--- a/src/bidsflow/scheduler/models.py
+++ b/src/bidsflow/scheduler/models.py
@@ -9,12 +9,14 @@ from bidsflow.core.stages import StageId
 @dataclass(frozen=True)
 class LaunchSpec:
     stage: StageId
-    participant: str | None
+    subject_label: str | None
+    session_label: str | None
     job_name: str
     cwd: Path
     command: tuple[str, ...]
     stdout_path: Path
     stderr_path: Path
+    prepare_paths: tuple[Path, ...] = ()
     env: dict[str, str] = field(default_factory=dict)
 
 

--- a/src/bidsflow/scheduler/sge.py
+++ b/src/bidsflow/scheduler/sge.py
@@ -17,6 +17,7 @@ from bidsflow.scheduler.models import (
     SGERequestedResources,
     SubmittedJob,
 )
+from bidsflow.stages.heudiconv import build_run_command, format_session_label, format_subject_label
 
 
 def _slugify(value: str) -> str:
@@ -25,37 +26,65 @@ def _slugify(value: str) -> str:
     return normalized or "job"
 
 
-def build_stage_launch_spec(config_path: Path, config: Config, stage: StageId, participant: str | None) -> LaunchSpec:
+def build_stage_launch_spec(
+    config_path: Path,
+    config: Config,
+    stage: StageId,
+    subject_label: str | None,
+    session_label: str | None = None,
+) -> LaunchSpec:
     log_dir = config.execution.logs_root / "sge" / stage.value
     job_name_parts = ["bidsflow", stage.value]
-    if participant:
-        job_name_parts.append(participant)
+    if subject_label:
+        job_name_parts.append(format_subject_label(subject_label))
+    if session_label:
+        job_name_parts.append(format_session_label(session_label))
     job_name = _slugify("-".join(job_name_parts))
 
     stdout_path = log_dir / f"{job_name}.out"
     stderr_path = log_dir / f"{job_name}.err"
 
-    command = [
-        sys.executable,
-        "-m",
-        "bidsflow.cli",
-        stage.value,
-        "--config",
-        str(config_path.resolve()),
-        "--scheduler",
-        "local",
-    ]
-    if participant:
-        command.extend(["--participant", participant])
+    prepare_paths: tuple[Path, ...] = ()
+    env: dict[str, str] = {}
+    cwd = config.project.root
+
+    if stage == StageId.HEUDICONV:
+        if subject_label is None:
+            raise ValueError("heudiconv launch specs require a subject label.")
+        command_spec = build_run_command(
+            config,
+            subject_label=subject_label,
+            session_label=session_label,
+        )
+        command = list(command_spec.command)
+        cwd = command_spec.cwd
+        env = command_spec.env
+        prepare_paths = (config.heudiconv.outdir.parent,)
+    else:
+        command = [
+            sys.executable,
+            "-m",
+            "bidsflow.cli",
+            stage.value,
+            "--config",
+            str(config_path.resolve()),
+            "--scheduler",
+            "local",
+        ]
+        if subject_label:
+            command.extend(["--subject-label", subject_label])
 
     return LaunchSpec(
         stage=stage,
-        participant=participant,
+        subject_label=subject_label,
+        session_label=session_label,
         job_name=job_name,
-        cwd=config.project.root,
+        cwd=cwd,
         command=tuple(command),
         stdout_path=stdout_path,
         stderr_path=stderr_path,
+        prepare_paths=prepare_paths,
+        env=env,
     )
 
 
@@ -92,10 +121,17 @@ class SGECliScheduler:
         config_path: Path,
         config: Config,
         stage: StageId,
-        participant: str | None,
+        subject_label: str | None,
+        session_label: str | None = None,
         hold_jid: str | None = None,
     ) -> SGEPlannedSubmission:
-        launch = build_stage_launch_spec(config_path=config_path, config=config, stage=stage, participant=participant)
+        launch = build_stage_launch_spec(
+            config_path=config_path,
+            config=config,
+            stage=stage,
+            subject_label=subject_label,
+            session_label=session_label,
+        )
         resources = self.requested_resources()
         script_path = config.execution.state_root / "sge" / f"{launch.job_name}.sh"
         script_text = self.render_script(launch)
@@ -119,6 +155,8 @@ class SGECliScheduler:
             "set -eu",
             f"cd {shlex.quote(str(launch.cwd))}",
         ]
+        for path in launch.prepare_paths:
+            lines.append(f"mkdir -p {shlex.quote(str(path))}")
         for key, value in sorted(launch.env.items()):
             lines.append(f"export {key}={shlex.quote(value)}")
         lines.append(f"exec {shlex.join(launch.command)}")

--- a/src/bidsflow/stages/__init__.py
+++ b/src/bidsflow/stages/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+

--- a/src/bidsflow/stages/heudiconv.py
+++ b/src/bidsflow/stages/heudiconv.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import glob
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, Sequence
+
+from bidsflow.config.models import Config
+
+CheckStatus = Literal["ready", "warning", "blocked"]
+HeudiconvMode = Literal["bootstrap", "run"]
+
+
+@dataclass(frozen=True)
+class ScopeUnit:
+    subject_label: str
+    session_label: str | None = None
+
+    @property
+    def bids_subject(self) -> str:
+        return format_subject_label(self.subject_label)
+
+    @property
+    def bids_session(self) -> str | None:
+        if self.session_label is None:
+            return None
+        return format_session_label(self.session_label)
+
+    @property
+    def display_name(self) -> str:
+        if self.session_label is None:
+            return self.bids_subject
+        return f"{self.bids_subject}/{self.bids_session}"
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    command: tuple[str, ...]
+    cwd: Path
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ReadinessResult:
+    status: CheckStatus
+    units: tuple[ScopeUnit, ...]
+    messages: tuple[str, ...]
+
+
+def normalize_subject_label(label: str) -> str:
+    return _normalize_label(label, prefix="sub-", kind="subject")
+
+
+def normalize_session_label(label: str) -> str:
+    return _normalize_label(label, prefix="ses-", kind="session")
+
+
+def format_subject_label(label: str) -> str:
+    return f"sub-{normalize_subject_label(label)}"
+
+
+def format_session_label(label: str) -> str:
+    return f"ses-{normalize_session_label(label)}"
+
+
+def discover_scope_units(
+    config: Config,
+    *,
+    subject_label: str | None,
+    session_label: str | None,
+    all_units: bool,
+) -> list[ScopeUnit]:
+    if session_label is not None and subject_label is None:
+        raise ValueError("--session-label requires --subject-label.")
+
+    source_root = config.project.sourcedata_root
+    if not source_root.exists():
+        raise ValueError(f"sourcedata root does not exist: {source_root}")
+    if not source_root.is_dir():
+        raise ValueError(f"sourcedata root is not a directory: {source_root}")
+
+    subject_dirs = [entry for entry in sorted(source_root.iterdir()) if entry.is_dir()]
+    if not subject_dirs:
+        return []
+
+    if all_units:
+        discovered: list[ScopeUnit] = []
+        for discovered_subject_dir in subject_dirs:
+            discovered.extend(_discover_subject_units(discovered_subject_dir))
+        return discovered
+
+    if subject_label is None:
+        raise ValueError("Specify --subject-label or --all to select HeuDiConv scope.")
+
+    subject_dir = _find_matching_dir(subject_dirs, normalize_subject_label(subject_label))
+    if subject_dir is None:
+        raise ValueError(f"subject not found under sourcedata root: {format_subject_label(subject_label)}")
+
+    if session_label is not None:
+        session_dirs = _candidate_session_dirs(subject_dir)
+        if not session_dirs:
+            raise ValueError(
+                f"session requested for subject without discoverable session directories: "
+                f"{format_subject_label(subject_label)}"
+            )
+        matched = _find_matching_dir(session_dirs, normalize_session_label(session_label))
+        if matched is None:
+            raise ValueError(
+                f"session not found for {format_subject_label(subject_label)}: "
+                f"{format_session_label(session_label)}"
+            )
+        return [ScopeUnit(subject_label=normalize_subject_label(subject_label), session_label=normalize_session_label(session_label))]
+
+    units = _discover_subject_units(subject_dir)
+    if units:
+        return units
+    return [ScopeUnit(subject_label=normalize_subject_label(subject_label))]
+
+
+def build_run_command(
+    config: Config,
+    *,
+    subject_label: str,
+    session_label: str | None,
+    files: Sequence[Path] = (),
+) -> CommandSpec:
+    heuristic = config.heudiconv.heuristic
+    if heuristic is None:
+        raise ValueError("heudiconv.heuristic must be set for run mode.")
+    if not heuristic.exists():
+        raise ValueError(f"HeuDiConv heuristic does not exist: {heuristic}")
+
+    return _build_command(
+        config,
+        mode="run",
+        subject_label=subject_label,
+        session_label=session_label,
+        files=files,
+        heuristic=str(heuristic),
+        converter=config.heudiconv.converter,
+    )
+
+
+def build_bootstrap_command(
+    config: Config,
+    *,
+    subject_label: str,
+    session_label: str | None,
+    files: Sequence[Path] = (),
+) -> CommandSpec:
+    return _build_command(
+        config,
+        mode="bootstrap",
+        subject_label=subject_label,
+        session_label=session_label,
+        files=files,
+        heuristic="convertall",
+        converter="none",
+    )
+
+
+def check_readiness(
+    config: Config,
+    *,
+    mode: HeudiconvMode,
+    subject_label: str | None,
+    session_label: str | None,
+    all_units: bool,
+    files: Sequence[Path] = (),
+) -> ReadinessResult:
+    status: CheckStatus = "ready"
+    messages: list[str] = []
+
+    if not config.heudiconv.enabled:
+        return ReadinessResult(
+            status="blocked",
+            units=(),
+            messages=("heudiconv stage is disabled in the project config.",),
+        )
+
+    units: list[ScopeUnit] = []
+    if files:
+        if all_units:
+            return ReadinessResult(
+                status="blocked",
+                units=(),
+                messages=("--all cannot be combined with explicit --files inputs.",),
+            )
+        if subject_label is None:
+            return ReadinessResult(
+                status="blocked",
+                units=(),
+                messages=("--files requires --subject-label so BIDSFlow can name the output scope.",),
+            )
+        if session_label is not None:
+            units = [ScopeUnit(normalize_subject_label(subject_label), normalize_session_label(session_label))]
+        else:
+            units = [ScopeUnit(normalize_subject_label(subject_label))]
+        missing_files = [path for path in files if not path.exists()]
+        if missing_files:
+            return ReadinessResult(
+                status="blocked",
+                units=tuple(units),
+                messages=tuple(f"input file does not exist: {path}" for path in missing_files),
+            )
+    else:
+        try:
+            units = discover_scope_units(
+                config,
+                subject_label=subject_label,
+                session_label=session_label,
+                all_units=all_units,
+            )
+        except ValueError as error:
+            return ReadinessResult(status="blocked", units=(), messages=(str(error),))
+
+    if not units:
+        return ReadinessResult(
+            status="blocked",
+            units=(),
+            messages=("no HeuDiConv execution units were discovered from the current selection.",),
+        )
+
+    backend_messages = _check_backend(config)
+    for entry_status, text in backend_messages:
+        status = _merge_status(status, entry_status)
+        messages.append(text)
+
+    if mode == "run":
+        heuristic = config.heudiconv.heuristic
+        if heuristic is None:
+            return ReadinessResult(
+                status="blocked",
+                units=tuple(units),
+                messages=("heudiconv.heuristic is not set; run mode requires a heuristic.py file.",),
+            )
+        if not heuristic.exists():
+            return ReadinessResult(
+                status="blocked",
+                units=tuple(units),
+                messages=(f"HeuDiConv heuristic does not exist: {heuristic}",),
+            )
+
+    if not files:
+        template = config.heudiconv.dicom_dir_template
+        if template is None:
+            return ReadinessResult(
+                status="blocked",
+                units=tuple(units),
+                messages=("heudiconv.dicom_dir_template is not set; provide a template or explicit files.",),
+            )
+
+        for unit in units:
+            try:
+                resolved_template = resolve_dicom_dir_template(
+                    config,
+                    subject_label=unit.subject_label,
+                    session_label=unit.session_label,
+                )
+            except ValueError as error:
+                return ReadinessResult(status="blocked", units=tuple(units), messages=(str(error),))
+
+            matches = sorted(glob.glob(resolved_template))
+            if not matches:
+                status = _merge_status(status, "blocked")
+                messages.append(f"no DICOM inputs matched for {unit.display_name}: {resolved_template}")
+
+    outdir = config.heudiconv.outdir
+    if outdir.exists() and not outdir.is_dir():
+        status = _merge_status(status, "blocked")
+        messages.append(f"HeuDiConv output root is not a directory: {outdir}")
+    elif not outdir.exists():
+        status = _merge_status(status, "warning")
+        messages.append(f"HeuDiConv output root will be created on first run: {outdir}")
+
+    if not messages:
+        messages.append(f"HeuDiConv {mode} is ready for {len(units)} scope unit(s).")
+
+    return ReadinessResult(status=status, units=tuple(units), messages=tuple(messages))
+
+
+def resolve_dicom_dir_template(
+    config: Config,
+    *,
+    subject_label: str,
+    session_label: str | None,
+) -> str:
+    template = config.heudiconv.dicom_dir_template
+    if template is None:
+        raise ValueError("heudiconv.dicom_dir_template is not configured.")
+
+    if session_label is None and ("{session" in template or "{bids_session" in template):
+        raise ValueError(
+            "The configured dicom_dir_template expects a session placeholder, but the selected "
+            "scope has no session label."
+        )
+
+    formatted = template.format(
+        subject=normalize_subject_label(subject_label),
+        session="" if session_label is None else normalize_session_label(session_label),
+        subject_label=normalize_subject_label(subject_label),
+        session_label="" if session_label is None else normalize_session_label(session_label),
+        bids_subject=format_subject_label(subject_label),
+        bids_session="" if session_label is None else format_session_label(session_label),
+    )
+    candidate = Path(formatted)
+    if candidate.is_absolute():
+        return str(candidate)
+    return str((config.project.sourcedata_root / candidate).resolve())
+
+
+def find_bootstrap_heuristic(outdir: Path, *, subject_label: str, session_label: str | None) -> Path | None:
+    return _find_latest_info_artifact(
+        outdir,
+        artifact_name="heuristic.py",
+        subject_label=subject_label,
+        session_label=session_label,
+    )
+
+
+def find_bootstrap_dicominfo(outdir: Path, *, subject_label: str, session_label: str | None) -> Path | None:
+    return _find_latest_info_artifact(
+        outdir,
+        artifact_name="dicominfo.tsv",
+        subject_label=subject_label,
+        session_label=session_label,
+    )
+
+
+def _normalize_label(label: str, *, prefix: str, kind: str) -> str:
+    normalized = label.strip()
+    if normalized.startswith(prefix):
+        normalized = normalized[len(prefix) :]
+    if not normalized:
+        raise ValueError(f"{kind} label cannot be empty.")
+    return normalized
+
+
+def _discover_subject_units(subject_dir: Path) -> list[ScopeUnit]:
+    subject_label = normalize_subject_label(subject_dir.name)
+    session_dirs = _candidate_session_dirs(subject_dir)
+    if not session_dirs:
+        return [ScopeUnit(subject_label=subject_label)]
+    return [
+        ScopeUnit(subject_label=subject_label, session_label=normalize_session_label(session_dir.name))
+        for session_dir in session_dirs
+    ]
+
+
+def _candidate_session_dirs(subject_dir: Path) -> list[Path]:
+    directories = [entry for entry in sorted(subject_dir.iterdir()) if entry.is_dir()]
+    prefixed = [entry for entry in directories if entry.name.startswith("ses-")]
+    if prefixed:
+        return prefixed
+
+    numeric = [entry for entry in directories if entry.name.isdigit()]
+    if numeric and len(numeric) == len(directories):
+        return directories
+
+    return []
+
+
+def _find_matching_dir(directories: Sequence[Path], normalized_label: str) -> Path | None:
+    for directory in directories:
+        name = directory.name
+        if name.startswith("sub-"):
+            current = normalize_subject_label(name)
+        elif name.startswith("ses-"):
+            current = normalize_session_label(name)
+        else:
+            current = name
+        if current == normalized_label:
+            return directory
+    return None
+
+
+def _build_command(
+    config: Config,
+    *,
+    mode: HeudiconvMode,
+    subject_label: str,
+    session_label: str | None,
+    files: Sequence[Path],
+    heuristic: str,
+    converter: Literal["dcm2niix", "none"],
+) -> CommandSpec:
+    tool_args: list[str] = []
+
+    if files:
+        tool_args.append("--files")
+        tool_args.extend(str(path.resolve()) for path in files)
+    else:
+        tool_args.extend(
+            [
+                "-d",
+                resolve_dicom_dir_template(
+                    config,
+                    subject_label=subject_label,
+                    session_label=session_label,
+                ),
+            ]
+        )
+
+    tool_args.extend(["-o", str(config.heudiconv.outdir), "-f", heuristic, "-s", normalize_subject_label(subject_label)])
+    if session_label is not None:
+        tool_args.extend(["-ss", normalize_session_label(session_label)])
+    tool_args.extend(["-c", converter])
+    if mode == "run":
+        tool_args.append("-b")
+    if config.heudiconv.minmeta:
+        tool_args.append("--minmeta")
+    if config.heudiconv.overwrite:
+        tool_args.append("--overwrite")
+    if config.heudiconv.with_prov:
+        tool_args.append("--with-prov")
+    if config.heudiconv.dcmconfig is not None:
+        tool_args.extend(["--dcmconfig", str(config.heudiconv.dcmconfig)])
+
+    backend = config.execution.backend
+    executable = config.heudiconv.executable
+    if backend == "native":
+        return CommandSpec(command=(executable, *tool_args), cwd=config.project.root)
+
+    bind_paths = _collect_bind_paths(config, files)
+    if backend == "apptainer":
+        apptainer_image = config.heudiconv.apptainer_image
+        if apptainer_image is None:
+            raise ValueError("heudiconv.apptainer_image must be set when execution.backend=apptainer.")
+        command: list[str] = ["apptainer", "exec", "--cleanenv"]
+        for bind_path in bind_paths:
+            command.extend(["--bind", f"{bind_path}:{bind_path}"])
+        command.extend([str(apptainer_image), executable, *tool_args])
+        return CommandSpec(command=tuple(command), cwd=config.project.root)
+
+    docker_image = config.heudiconv.docker_image
+    if docker_image is None:
+        raise ValueError("heudiconv.docker_image must be set when execution.backend=docker.")
+    command = ["docker", "run", "--rm"]
+    for bind_path in bind_paths:
+        command.extend(["-v", f"{bind_path}:{bind_path}"])
+    command.extend([docker_image, executable, *tool_args])
+    return CommandSpec(command=tuple(command), cwd=config.project.root)
+
+
+def _collect_bind_paths(config: Config, files: Sequence[Path]) -> list[Path]:
+    bind_paths = {
+        config.project.sourcedata_root.resolve(),
+        config.heudiconv.outdir.parent.resolve(),
+    }
+    if config.heudiconv.heuristic is not None:
+        bind_paths.add(config.heudiconv.heuristic.parent.resolve())
+    if config.heudiconv.dcmconfig is not None:
+        bind_paths.add(config.heudiconv.dcmconfig.parent.resolve())
+    for path in files:
+        resolved = path.resolve()
+        bind_paths.add(resolved if resolved.is_dir() else resolved.parent)
+    return sorted(bind_paths, key=str)
+
+
+def _check_backend(config: Config) -> list[tuple[CheckStatus, str]]:
+    backend = config.execution.backend
+    messages: list[tuple[CheckStatus, str]] = []
+
+    if backend == "native":
+        executable = config.heudiconv.executable
+        if shutil.which(executable) is None:
+            messages.append(("blocked", f"native HeuDiConv executable is not available in PATH: {executable}"))
+        else:
+            messages.append(("ready", f"native HeuDiConv executable resolved from PATH: {executable}"))
+        return messages
+
+    if backend == "apptainer":
+        if shutil.which("apptainer") is None:
+            messages.append(("blocked", "apptainer is not available in PATH."))
+        apptainer_image = config.heudiconv.apptainer_image
+        if apptainer_image is None:
+            messages.append(("blocked", "heudiconv.apptainer_image is not configured."))
+        elif not apptainer_image.exists():
+            messages.append(("blocked", f"HeuDiConv Apptainer image does not exist: {apptainer_image}"))
+        else:
+            messages.append(("ready", f"HeuDiConv Apptainer image resolved: {apptainer_image}"))
+        return messages
+
+    if shutil.which("docker") is None:
+        messages.append(("blocked", "docker is not available in PATH."))
+    docker_image = config.heudiconv.docker_image
+    if docker_image is None:
+        messages.append(("blocked", "heudiconv.docker_image is not configured."))
+    else:
+        messages.append(("ready", f"HeuDiConv Docker image configured: {docker_image}"))
+    return messages
+
+
+def _find_latest_info_artifact(
+    outdir: Path,
+    *,
+    artifact_name: str,
+    subject_label: str,
+    session_label: str | None,
+) -> Path | None:
+    info_root = outdir / ".heudiconv"
+    if not info_root.exists():
+        return None
+
+    subject_tokens = {normalize_subject_label(subject_label), format_subject_label(subject_label)}
+    session_tokens = {""}
+    if session_label is not None:
+        session_tokens = {normalize_session_label(session_label), format_session_label(session_label)}
+
+    matches: list[Path] = []
+    for candidate in info_root.rglob(artifact_name):
+        candidate_parts = set(candidate.parts)
+        if not subject_tokens.intersection(candidate_parts):
+            continue
+        if session_label is not None and not session_tokens.intersection(candidate_parts):
+            continue
+        matches.append(candidate)
+
+    if not matches:
+        return None
+    matches.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    return matches[0]
+
+
+def _merge_status(current: CheckStatus, new: CheckStatus) -> CheckStatus:
+    order = {"ready": 0, "warning": 1, "blocked": 2}
+    if order[new] > order[current]:
+        return new
+    return current

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -11,6 +11,7 @@ def test_load_config_resolves_paths_relative_to_project_root() -> None:
 
     assert config.execution.scheduler == "sge"
     assert config.project.root == repo_root
+    assert config.project.sourcedata_root == repo_root / "sourcedata" / "dicom"
     assert config.execution.logs_root == repo_root / "logs"
     assert config.execution.state_root == repo_root / "state"
     assert config.heudiconv.heuristic == repo_root / "code" / "heuristics" / "heuristic.py"

--- a/tests/test_heudiconv.py
+++ b/tests/test_heudiconv.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from bidsflow.cli import app
+from bidsflow.config.load import load_config
+from bidsflow.core.stages import StageId
+from bidsflow.scheduler.sge import SGECliScheduler
+from bidsflow.stages.heudiconv import discover_scope_units
+
+
+def _write_heudiconv_config(tmp_path: Path, *, scheduler: str = "local") -> Path:
+    project_root = tmp_path / "project"
+    source_root = project_root / "sourcedata" / "dicom" / "sub-001" / "ses-01" / "scanner"
+    source_root.mkdir(parents=True, exist_ok=True)
+    (source_root / "IM-0001.dcm").write_text("mock", encoding="utf-8")
+
+    heuristic = project_root / "code" / "heuristics" / "heuristic.py"
+    heuristic.parent.mkdir(parents=True, exist_ok=True)
+    heuristic.write_text("def infotodict(seqinfo):\n    return {}\n", encoding="utf-8")
+
+    config_path = project_root / "bidsflow.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "HeuDiConv test project"',
+                'root = "."',
+                'sourcedata_root = "sourcedata/dicom"',
+                'bids_root = "sourcedata/raw"',
+                'derivatives_root = "derivatives"',
+                "",
+                "[execution]",
+                'backend = "native"',
+                f'scheduler = "{scheduler}"',
+                'work_root = "work"',
+                'logs_root = "logs"',
+                'state_root = "state"',
+                "",
+                "[heudiconv]",
+                'enabled = true',
+                'executable = "heudiconv"',
+                'dicom_dir_template = "{bids_subject}/{bids_session}/*/*.dcm"',
+                'heuristic = "code/heuristics/heuristic.py"',
+                'outdir = "sourcedata/raw"',
+                'converter = "dcm2niix"',
+                'overwrite = true',
+                "",
+                "[scheduler.sge.default_resources]",
+                "slots = 1",
+                'walltime = "00:10:00"',
+                'memory = "1G"',
+                "",
+                "[scheduler.sge.resource_map]",
+                'walltime = "h_rt"',
+                'memory = "mem_free"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_discover_scope_units_finds_subject_and_session(tmp_path: Path) -> None:
+    config_path = _write_heudiconv_config(tmp_path)
+    config = load_config(config_path)
+
+    units = discover_scope_units(
+        config,
+        subject_label=None,
+        session_label=None,
+        all_units=True,
+    )
+
+    assert len(units) == 1
+    assert units[0].subject_label == "001"
+    assert units[0].session_label == "01"
+
+
+def test_heudiconv_bootstrap_dry_run_builds_convertall_command(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    config_path = _write_heudiconv_config(tmp_path)
+
+    monkeypatch.setattr("bidsflow.stages.heudiconv.shutil.which", lambda _: "/usr/bin/mock")
+
+    result = runner.invoke(
+        app,
+        [
+            "heudiconv",
+            "bootstrap",
+            "--config",
+            str(config_path),
+            "--subject-label",
+            "sub-001",
+            "--session-label",
+            "ses-01",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "HeuDiConv bootstrap preview" in result.stdout
+    assert "convertall" in result.stdout
+    assert "-c none" in result.stdout
+
+
+def test_heudiconv_run_dry_run_uses_real_command(monkeypatch, tmp_path: Path) -> None:
+    runner = CliRunner()
+    config_path = _write_heudiconv_config(tmp_path)
+
+    monkeypatch.setattr("bidsflow.stages.heudiconv.shutil.which", lambda _: "/usr/bin/mock")
+
+    result = runner.invoke(
+        app,
+        [
+            "heudiconv",
+            "run",
+            "--config",
+            str(config_path),
+            "--subject-label",
+            "sub-001",
+            "--session-label",
+            "ses-01",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "HeuDiConv run preview" in result.stdout
+    assert "heudiconv -d" in result.stdout
+    assert "-f" in result.stdout
+    assert "-s 001" in result.stdout
+    assert "-ss 01" in result.stdout
+    assert "sub-001/ses-01" in result.stdout
+
+
+def test_heudiconv_sge_plan_uses_real_command(monkeypatch, tmp_path: Path) -> None:
+    config_path = _write_heudiconv_config(tmp_path, scheduler="sge")
+    config = load_config(config_path)
+    scheduler = SGECliScheduler(config.scheduler.sge)
+
+    monkeypatch.setattr("bidsflow.stages.heudiconv.shutil.which", lambda _: "/usr/bin/mock")
+
+    plan = scheduler.plan_stage_submission(
+        config_path=config_path,
+        config=config,
+        stage=StageId.HEUDICONV,
+        subject_label="001",
+        session_label="01",
+    )
+
+    assert plan.launch.job_name == "bidsflow-heudiconv-sub-001-ses-01"
+    assert plan.launch.command[0] == "heudiconv"
+    assert "-d" in plan.launch.command
+    assert "-s" in plan.launch.command
+    assert "-ss" in plan.launch.command
+    assert "-b" in plan.launch.command
+    assert "mkdir -p" in plan.script_text

--- a/tests/test_scheduler_sge.py
+++ b/tests/test_scheduler_sge.py
@@ -22,7 +22,7 @@ def test_plan_stage_submission_renders_qsub_command_and_script() -> None:
         config_path=config_path,
         config=config,
         stage=StageId.FMRIPREP,
-        participant="sub-001",
+        subject_label="sub-001",
         hold_jid="1234",
     )
 
@@ -47,7 +47,7 @@ def test_plan_stage_submission_renders_qsub_command_and_script() -> None:
     assert "#!/bin/sh" in plan.script_text
     assert "set -eu" in plan.script_text
     assert "bidsflow.cli fmriprep --config" in plan.script_text
-    assert "--participant sub-001" in plan.script_text
+    assert "--subject-label sub-001" in plan.script_text
     assert "--scheduler local" in plan.script_text
 
 
@@ -144,7 +144,7 @@ def test_submit_and_cancel_use_external_commands(monkeypatch, tmp_path: Path) ->
         config_path=config_path,
         config=config,
         stage=StageId.FMRIPREP,
-        participant="sub-001",
+        subject_label="sub-001",
     )
     plan = type(plan)(
         launch=plan.launch,
@@ -217,7 +217,7 @@ def test_stage_dry_run_uses_configured_sge_scheduler() -> None:
             "fmriprep",
             "--config",
             str(config_path),
-            "--participant",
+            "--subject-label",
             "sub-001",
             "--dry-run",
         ],
@@ -249,7 +249,7 @@ def test_stage_run_submits_sge_job_from_config(monkeypatch) -> None:
             "fmriprep",
             "--config",
             str(config_path),
-            "--participant",
+            "--subject-label",
             "sub-001",
         ],
     )
@@ -269,7 +269,7 @@ def test_stage_run_supports_local_scheduler_override() -> None:
             "fmriprep",
             "--config",
             str(config_path),
-            "--participant",
+            "--subject-label",
             "sub-001",
             "--scheduler",
             "local",
@@ -291,10 +291,10 @@ def test_validate_stage_rejects_participant_argument() -> None:
             "validate",
             "--config",
             str(config_path),
-            "--participant",
+            "--subject-label",
             "sub-001",
         ],
     )
 
     assert result.exit_code == 2
-    assert "does not accept --participant" in result.stdout
+    assert "does not accept --subject-label" in result.stdout


### PR DESCRIPTION
## Goal
Implement the HeuDiConv stage end to end, while establishing CLI and configuration conventions that will also support later stages without forcing premature symmetry.

## Implemented in this PR so far
- add a real heudiconv stage id and user-facing idsflow heudiconv command group
- implement heudiconv bootstrap, heudiconv check, and heudiconv run
- add HeuDiConv scope discovery, subject/session normalization, and real command construction
- wire HeuDiConv launch specs into local execution and SGE submission instead of the old placeholder recursion path
- extend the config schema and example project config for sourcedata roots and HeuDiConv-specific defaults
- update README, design docs, and skill references to match the implemented command/config conventions
- add HeuDiConv-focused tests and refresh the existing scheduler/config tests

## Validation
- python -m pytest
- python -m mypy src
- python -m ruff check .

## Remaining follow-up likely to happen after this PR
- extend the same capability-oriented CLI patterns to the non-HeuDiConv stages
- replace the remaining placeholder command builders with real tool-specific launch specs
- grow the handoff/state model beyond the current stage boundary groundwork